### PR TITLE
feat: add inventory sorting

### DIFF
--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -149,6 +149,13 @@ module.exports = {
 							}
 						)
 				)
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('sort')
+				.setNameLocalization('pt-BR', 'ordenação')
+				.setDescription('Change inventory sorting method')
+				.setDescriptionLocalization('pt-BR', 'Muda o método de ordenação do inventário')
 		),
 	execute: async ({ guild, interaction, instance, member, subcommand }) => {
 		try {

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -20,9 +20,9 @@ module.exports = {
 			const items = instance.items;
 
 			if (interaction.options !== undefined) {
-				var item = interaction.options.getString('item').toLowerCase();
+				var item = interaction.options.getString('item');
 			} else {
-				var item = interaction.customId.split(' ')[1].toLowerCase();
+				var item = interaction.customId.split(' ')[1];
 				var cont = 0;
 				for (i in items) {
 					if (i == item) {
@@ -31,7 +31,6 @@ module.exports = {
 					}
 					cont++;
 				}
-				console.log(index);
 				if (index < 0) index = Object.keys(items).length - 1;
 				if (index > Object.keys(items).length - 1) index = 0;
 				item = Object.keys(items)[index];

--- a/src/events/interactions.js
+++ b/src/events/interactions.js
@@ -133,7 +133,8 @@ module.exports = {
 			if (
 				interaction.customId === 'inventory view' ||
 				interaction.customId === 'inventory craft' ||
-				interaction.customId.startsWith('craft')
+				interaction.customId.startsWith('craft') ||
+				interaction.customId === 'inventory sort'
 			) {
 				if (!interaction.customId.startsWith('craft')) {
 					var arguments = interaction.customId.split(' ');
@@ -200,16 +201,17 @@ module.exports = {
 			if (interaction.customId === 'page') {
 				const help = client.commands.get('help');
 				help.execute({ guild: interaction.guild, interaction, instance });
-			}
-
-			if (interaction.customId === 'craft') {
-				const inventory = client.commands.get('inventory');
-				await inventory.execute({
+			} else {
+				const command = client.commands.get(interaction.customId.split(' ')[0]);
+				await command.execute({
 					guild: interaction.guild,
 					interaction,
 					instance,
 					member: interaction.member,
-					subcommand: 'craft',
+					client,
+					user: interaction.user,
+					channel: interaction.channel,
+					subcommand: interaction.customId.split(' ')[1],
 				});
 			}
 		}

--- a/src/schemas/user-schema.js
+++ b/src/schemas/user-schema.js
@@ -62,6 +62,10 @@ const userSchema = mongoose.Schema(
 			type: String,
 			default: 'en-US',
 		},
+		inventorySort: {
+			type: String,
+			default: 'itemValue',
+		},
 	},
 	{
 		versionKey: false,

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -234,6 +234,7 @@ async function resolveCooldown(id, command) {
 }
 
 function getItem(item) {
+	item = item.toLowerCase();
 	for (const key in items) {
 		if (
 			items[key]['pt-BR'].split(' ').slice(1).join(' ').toLowerCase() === item ||

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1112,7 +1112,38 @@
 		"pt-BR": "Construir tudo",
 		"en-US": "Craft max"
 	},
-
+	"INVENTORY_SORTING": {
+		"pt-BR": "Ordenação do inventário",
+		"en-US": "Inventory sorting"
+	},
+	"SORTING_MENU": {
+		"pt-BR": "Use o menu abaixo para escolher o método de ordenação do inventário",
+		"en-US": "Use the menu below to choose the inventory sorting method"
+	},
+	"SORTING_PLACEHOLDER": {
+		"pt-BR": "Escolha o tipo de ordenação...",
+		"en-US": "Choose the sorting type..."
+	},
+	"ITEMVALUE": {
+		"pt-BR": "Valor do item",
+		"en-US": "Item value"
+	},
+	"WORTH": {
+		"pt-BR": "Valor total",
+		"en-US": "Worth"
+	},
+	"QUANTITY": {
+		"pt-BR": "Quantidade",
+		"en-US": "Quantity"
+	},
+	"ALPHABETICAL": {
+		"pt-BR": "Alfabético",
+		"en-US": "Alphabetical"
+	},
+	"SORTING_NOW": {
+		"pt-BR": "O inventário agora está ordenado por **{SORTING}**",
+		"en-US": "The inventory is now sorted by **{SORTING}**"
+	},
 	"1": {
 		"pt-BR": ":potato: Plebeu",
 		"en-US": ":potato: Peasent"


### PR DESCRIPTION
closes #28 

## O que este PR faz?
Adiciona 4 tipos diferentes de ordenação do inventário, que o usuário pode escolher entre elas

## Sumário das alterações
- Adiciona um novo campo inventorySort na schema do usuário
- Adiciona um novo botão ao ver o inventário que te permite mudar o tipo de ordenação
- 4 tipos de ordenação: valor do item, valor total, quantidade e alfabético
- adiciona .toLowerCase() direto no getItem(), remove dos outros lugares

## Mídia
![image](https://github.com/falcao-g/Falbot/assets/60127788/258787e6-048b-4b92-ab3d-c7965245ce11)
