### PR TITLE
Busca o nome dos itens corretamente

### DIFF
--- a/src/commands/explore.js
+++ b/src/commands/explore.js
@@ -38,7 +38,7 @@ module.exports = {
 			buff = 2;
 			await useItem(member, 'activewear');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['activewear'][interaction.locale],
+				ITEM: items['activewear'][interaction.locale] ?? items['activewear']['en-US'],
 				BUFF: 2,
 			})}**`;
 		}
@@ -47,7 +47,7 @@ module.exports = {
 			buff = 4;
 			await useItem(member, 'coat');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['coat'][interaction.locale],
+				ITEM: items['coat'][interaction.locale] ?? items['coat']['en-US'],
 				BUFF: 4,
 			})}**`;
 		}
@@ -85,8 +85,9 @@ module.exports = {
 		for (let i = 0; i < numItems; i++) {
 			var selectedItem = pick(filteredItems);
 			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * buff;
+			var name = items[selectedItem][interaction.locale] ?? items[selectedItem]['en-US'];
 			total += amount;
-			text += `**${items[selectedItem][interaction.locale]}** x ${amount}\n`;
+			text += `**${name}** x ${amount}\n`;
 			filteredItems = filteredItems.filter((item) => item[0] !== selectedItem);
 			inventory.set(selectedItem, (inventory.get(selectedItem) || 0) + amount);
 			selectedItems.push(selectedItem);

--- a/src/commands/fish.js
+++ b/src/commands/fish.js
@@ -38,7 +38,7 @@ module.exports = {
 			buff = 2;
 			await useItem(member, 'rod');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['rod'][interaction.locale],
+				ITEM: items['rod'][interaction.locale] ?? items['rod']['en-US'],
 				BUFF: 2,
 			})}**`;
 		}
@@ -47,7 +47,7 @@ module.exports = {
 			buff = 4;
 			await useItem(member, 'diarod');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['diarod'][interaction.locale],
+				ITEM: items['diarod'][interaction.locale] ?? items['diarod']['en-US'],
 				BUFF: 4,
 			})}**`;
 		}
@@ -85,8 +85,9 @@ module.exports = {
 		for (let i = 0; i < numItems; i++) {
 			var selectedItem = pick(filteredItems);
 			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * buff;
+			var name = items[selectedItem][interaction.locale] ?? items[selectedItem]['en-US'];
 			total += amount;
-			text += `**${items[selectedItem][interaction.locale]}** x ${amount}\n`;
+			text += `**${name}** x ${amount}\n`;
 			filteredItems = filteredItems.filter((item) => item[0] !== selectedItem);
 			inventory.set(selectedItem, (inventory.get(selectedItem) || 0) + amount);
 			selectedItems.push(selectedItem);

--- a/src/commands/hunt.js
+++ b/src/commands/hunt.js
@@ -38,7 +38,7 @@ module.exports = {
 			buff = 2;
 			await useItem(member, 'huntknife');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['huntknife'][interaction.locale],
+				ITEM: items['huntknife'][interaction.locale] ?? items['huntknife']['en-US'],
 				BUFF: 2,
 			})}**`;
 		}
@@ -47,7 +47,7 @@ module.exports = {
 			buff = 4;
 			await useItem(member, 'diaknife');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['diaknife'][interaction.locale],
+				ITEM: items['diaknife'][interaction.locale] ?? items['diaknife']['en-US'],
 				BUFF: 4,
 			})}**`;
 		}
@@ -85,8 +85,9 @@ module.exports = {
 		for (let i = 0; i < numItems; i++) {
 			var selectedItem = pick(filteredItems);
 			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * buff;
+			var name = items[selectedItem][interaction.locale] ?? items[selectedItem]['en-US'];
 			total += amount;
-			text += `**${items[selectedItem][interaction.locale]}** x ${amount}\n`;
+			text += `**${name}** x ${amount}\n`;
 			filteredItems = filteredItems.filter((item) => item[0] !== selectedItem);
 			inventory.set(selectedItem, (inventory.get(selectedItem) || 0) + amount);
 			selectedItems.push(selectedItem);

--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -190,7 +190,7 @@ module.exports = {
 				const inventoryItems = Array.from(inventory)
 					.reduce((acc, [itemName, quantity]) => {
 						if (quantity !== 0) {
-							acc.push(`${items[itemName][interaction.locale]} x ${quantity}`);
+							acc.push(`${items[itemName][interaction.locale] ?? items[itemName]['en-US']} x ${quantity}`);
 						}
 						return acc;
 					}, [])
@@ -290,7 +290,9 @@ module.exports = {
 					var ingredients = `**${instance.getMessage(interaction, 'INGREDIENTS')}**`;
 
 					for (key in itemJSON.recipe) {
-						ingredients += `\n${items[key][interaction.locale]} x ${itemJSON.recipe[key] * amount}`;
+						ingredients += `\n${items[key][interaction.locale] ?? items[key]['en-US']} x ${
+							itemJSON.recipe[key] * amount
+						}`;
 					}
 				}
 
@@ -298,7 +300,7 @@ module.exports = {
 					.setColor(await getRoleColor(guild, member.id))
 					.setTitle(instance.getMessage(interaction, 'CALCULATOR'))
 					.addFields({
-						name: `${itemJSON[interaction.locale]} x ${amount}`,
+						name: `${itemJSON[interaction.locale] ?? itemJSON['en-US']} x ${amount}`,
 						value: `${ingredients != undefined ? ingredients : ''}\n${instance.getMessage(
 							interaction,
 							'COST'
@@ -342,7 +344,7 @@ module.exports = {
 					.addFields({
 						name: instance.getMessage(interaction, 'SOLD_TITLE', {
 							AMOUNT: format(amount),
-							ITEM: itemJSON[interaction.locale],
+							ITEM: itemJSON[interaction.locale] ?? itemJSON['en-US'],
 							FALCOINS: format(falcoins),
 						}),
 						value: instance.getMessage(interaction, 'SOLD_FIELD', {
@@ -369,10 +371,9 @@ module.exports = {
 					listItems = [];
 					for (key in items) {
 						if (items[key].equip === true) {
+							const name = items[key][interaction.locale] ?? items[key]['en-US'];
 							listItems.push(
-								items[key][interaction.locale] +
-									' - ' +
-									instance.getMessage(interaction, items[key]['effect'].toUpperCase()).split(':')[2]
+								name + ' - ' + instance.getMessage(interaction, items[key]['effect'].toUpperCase()).split(':')[2]
 							);
 						}
 					}
@@ -429,10 +430,10 @@ module.exports = {
 					.setColor(await getRoleColor(guild, member.id))
 					.addFields({
 						name: instance.getMessage(interaction, 'EQUIPPED_TITLE', {
-							ITEM: itemJSON[interaction.locale],
+							ITEM: itemJSON[interaction.locale] ?? itemJSON['en-US'],
 						}),
 						value: instance.getMessage(interaction, 'EQUIPPED_VALUE', {
-							ITEM: itemJSON[interaction.locale],
+							ITEM: itemJSON[interaction.locale] ?? itemJSON['en-US'],
 						}),
 					})
 					.setFooter({ text: 'by Falcão ❤️' });
@@ -475,8 +476,10 @@ module.exports = {
 											if ((inventory.get(key) || 0) < items[item].recipe[key]) return;
 										}
 
+										const name = items[item][interaction.locale] ?? items[item]['en-US'];
+
 										return {
-											label: items[item][interaction.locale].split(':')[2],
+											label: name.split(':')[2],
 											value: item,
 											emoji: items[item].emoji,
 										};
@@ -527,12 +530,16 @@ module.exports = {
 
 					if ((inventory.get(key) || 0) < ingredientAmount) {
 						missingIngredients.push(
-							`${ingredientJSON[interaction.locale]} x ${format(ingredientAmount - (inventory.get(key) || 0))}`
+							`${ingredientJSON[interaction.locale] ?? ingredientJSON['en-US']} x ${format(
+								ingredientAmount - (inventory.get(key) || 0)
+							)}`
 						);
 					}
 
 					inventory.set(key, inventory.get(key) - ingredientAmount);
-					ingredients.push(`${ingredientJSON[interaction.locale]}: ${format(ingredientAmount)}`);
+					ingredients.push(
+						`${ingredientJSON[interaction.locale] ?? ingredientJSON['en-US']}: ${format(ingredientAmount)}`
+					);
 				}
 
 				if (missingIngredients.length > 0) {
@@ -562,12 +569,12 @@ module.exports = {
 					.setColor(await getRoleColor(guild, member.id))
 					.addFields({
 						name: instance.getMessage(interaction, 'CRAFTED_TITLE', {
-							ITEM: itemJSON[interaction.locale],
+							ITEM: itemJSON[interaction.locale] ?? itemJSON['en-US'],
 							AMOUNT: format(amount),
 						}),
 						value: instance.getMessage(interaction, 'CRAFTED_VALUE', {
 							INGREDIENTS: ingredients.join('\n'),
-							ITEM: itemJSON[interaction.locale],
+							ITEM: itemJSON[interaction.locale] ?? itemJSON['en-US'],
 							AMOUNT: format(amount),
 							MAXAMOUNT: format(maxAmount),
 						}),
@@ -645,7 +652,7 @@ module.exports = {
 						}
 
 						falcoins += itemJSON.value * inventory.get(key);
-						itemsSold.push(`${itemJSON[interaction.locale]}: ${format(inventory.get(key))}`);
+						itemsSold.push(`${itemJSON[interaction.locale] ?? itemJSON['en-US']}: ${format(inventory.get(key))}`);
 						inventory.set(key, 0);
 					}
 

--- a/src/commands/mine.js
+++ b/src/commands/mine.js
@@ -38,7 +38,7 @@ module.exports = {
 			buff = 2;
 			await useItem(member, 'ironpick');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['ironpick'][interaction.locale],
+				ITEM: items['ironpick'][interaction.locale] ?? items['ironpick']['en-US'],
 				BUFF: 2,
 			})}**`;
 		}
@@ -47,7 +47,7 @@ module.exports = {
 			buff = 4;
 			await useItem(member, 'diapick');
 			buffText = `**${instance.getMessage(interaction, 'BUFF', {
-				ITEM: items['diapick'][interaction.locale],
+				ITEM: items['diapick'][interaction.locale] ?? items['diapick']['en-US'],
 				BUFF: 4,
 			})}**`;
 		}
@@ -85,8 +85,9 @@ module.exports = {
 		for (let i = 0; i < numItems; i++) {
 			var selectedItem = pick(filteredItems);
 			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * buff;
+			var name = items[selectedItem][interaction.locale] ?? items[selectedItem]['en-US'];
 			total += amount;
-			text += `**${items[selectedItem][interaction.locale]}** x ${amount}\n`;
+			text += `**${name}** x ${amount}\n`;
 			filteredItems = filteredItems.filter((item) => item[0] !== selectedItem);
 			inventory.set(selectedItem, (inventory.get(selectedItem) || 0) + amount);
 			selectedItems.push(selectedItem);


### PR DESCRIPTION
## O que este PR faz?
conserta um erro onde o bot assumia que sua locale era pt-BR ou en-US para buscar o nome dos itens

## Sumário das alterações
- Em todos os lugares que existia uma expressão do tipo items[item][interaction.locale], foi adicionado um ?? items[item]['en-US'], que garante que um nome sempre será retornado