### PR TITLE
fix: inventory craft select menu limit

### DIFF
--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1172,6 +1172,10 @@
 		"pt-BR": ":school_satchel: +200.000 falcoins de limite ao inventário",
 		"en-US": ":school_satchel: +200.000 falcoins to inventory limit"
 	},
+	"NO_CRAFT_AVAILABLE": {
+		"pt-BR": "Você não pode construir nada no momento, use `/pescar`, `/minerar`, `/explorar` e `/caçar` para conseguir itens",
+		"en-US": "You can't craft anything at the moment, use `/fish`, `/mine`, `/explore` and `/hunt` to get items"
+	},
 	"1": {
 		"pt-BR": ":potato: Plebeu",
 		"en-US": ":potato: Peasent"


### PR DESCRIPTION
fixes #36 

## O que este PR faz?
Garante que as opções do menu de seleção do inventory craft serão entre 1 e 25

## Sumário das alterações
- Se o usuário puder construir mais de 25 items, cortamos pra 25
- Se ele não pode construir nenhum item, mandamos uma mensagem falando isso