### PR TITLE
feat: create autocomplete for items

### DIFF
--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -37,6 +37,7 @@ module.exports = {
 						.setDescription('item to calculate')
 						.setDescriptionLocalization('pt-BR', 'item para calcular')
 						.setRequired(true)
+						.setAutocomplete(true)
 				)
 				.addIntegerOption((option) =>
 					option
@@ -60,6 +61,7 @@ module.exports = {
 						.setDescription('item to sell')
 						.setDescriptionLocalization('pt-BR', 'item para vender')
 						.setRequired(true)
+						.setAutocomplete(true)
 				)
 				.addIntegerOption((option) =>
 					option
@@ -83,6 +85,7 @@ module.exports = {
 						.setDescription('item to equip')
 						.setDescriptionLocalization('pt-BR', 'item para equipar')
 						.setRequired(false)
+						.setAutocomplete(true)
 				)
 		)
 		.addSubcommand((subcommand) =>
@@ -97,6 +100,7 @@ module.exports = {
 						.setDescription('item to craft')
 						.setDescriptionLocalization('pt-BR', 'item para construir')
 						.setRequired(false)
+						.setAutocomplete(true)
 				)
 				.addIntegerOption((option) =>
 					option
@@ -154,6 +158,7 @@ module.exports = {
 						.setDescription('item to use')
 						.setDescriptionLocalization('pt-BR', 'item para ser usado')
 						.setRequired(true)
+						.setAutocomplete(true)
 				)
 		),
 	execute: async ({ guild, interaction, instance, member, subcommand, args }) => {
@@ -774,5 +779,48 @@ module.exports = {
 				components: [],
 			});
 		}
+	},
+	autocomplete: async ({ interaction, instance }) => {
+		console.log(interaction.options.getSubcommand());
+		const focusedValue = interaction.options.getFocused().toLowerCase();
+		const items = instance.items;
+		if (interaction.options.getSubcommand() === 'equip') {
+			var localeItems = Object.keys(items)
+				.map((key) => {
+					if (items[key].equip === true) {
+						var item = items[key][interaction.locale] ?? items[key]['en-US'];
+						return item.split(' ').slice(1).join(' ').toLowerCase();
+					}
+					return undefined;
+				})
+				.filter((item) => item !== undefined);
+		} else if (interaction.options.getSubcommand() === 'craft') {
+			var localeItems = Object.keys(items)
+				.map((key) => {
+					if (items[key].recipe != undefined) {
+						var item = items[key][interaction.locale] ?? items[key]['en-US'];
+						return item.split(' ').slice(1).join(' ').toLowerCase();
+					}
+					return undefined;
+				})
+				.filter((item) => item !== undefined);
+		} else if (interaction.options.getSubcommand() === 'use') {
+			var localeItems = Object.keys(items)
+				.map((key) => {
+					if (items[key].use != undefined) {
+						var item = items[key][interaction.locale] ?? items[key]['en-US'];
+						return item.split(' ').slice(1).join(' ').toLowerCase();
+					}
+					return undefined;
+				})
+				.filter((item) => item !== undefined);
+		} else {
+			var localeItems = Object.keys(items).map((key) => {
+				var item = items[key][interaction.locale] ?? items[key]['en-US'];
+				return item.split(' ').slice(1).join(' ').toLowerCase();
+			});
+		}
+		const filtered = localeItems.filter((choice) => choice.startsWith(focusedValue));
+		await interaction.respond(filtered.map((choice) => ({ name: choice, value: choice })).slice(0, 25));
 	},
 };

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -13,6 +13,7 @@ module.exports = {
 				.setDescription('item to see information about')
 				.setDescriptionLocalization('pt-BR', 'item para ver informações sobre')
 				.setRequired(true)
+				.setAutocomplete(true)
 		),
 	execute: async ({ interaction, instance, member, subcommand, args }) => {
 		try {
@@ -138,5 +139,15 @@ module.exports = {
 				embeds: [],
 			});
 		}
+	},
+	autocomplete: async ({ interaction, instance }) => {
+		const focusedValue = interaction.options.getFocused().toLowerCase();
+		const items = instance.items;
+		const localeItems = Object.keys(items).map((key) => {
+			var item = items[key][interaction.locale] ?? items[key]['en-US'];
+			return item.split(' ').slice(1).join(' ').toLowerCase();
+		});
+		const filtered = localeItems.filter((choice) => choice.startsWith(focusedValue));
+		await interaction.respond(filtered.map((choice) => ({ name: choice, value: choice })).slice(0, 25));
 	},
 };

--- a/src/commands/leaderboard.js
+++ b/src/commands/leaderboard.js
@@ -110,6 +110,7 @@ module.exports = {
 						.setDescription('item to be counted')
 						.setDescriptionLocalization('pt-BR', 'item a ser contado')
 						.setRequired(true)
+						.setAutocomplete(true)
 				)
 		)
 		.addSubcommand((subcommand) =>
@@ -254,5 +255,15 @@ module.exports = {
 				components: [],
 			});
 		}
+	},
+	autocomplete: async ({ interaction, instance }) => {
+		const focusedValue = interaction.options.getFocused().toLowerCase();
+		const items = instance.items;
+		const localeItems = Object.keys(items).map((key) => {
+			var item = items[key][interaction.locale] ?? items[key]['en-US'];
+			return item.split(' ').slice(1).join(' ').toLowerCase();
+		});
+		const filtered = localeItems.filter((choice) => choice.startsWith(focusedValue));
+		await interaction.respond(filtered.map((choice) => ({ name: choice, value: choice })).slice(0, 25));
 	},
 };


### PR DESCRIPTION
closes #35 

## What does this PR do?
Adds autocomplete for item throughout all commands

## Summary of changes
- Add autocomplete in leaderboard items
- Add autocomplete in iteminfo 
- Add autocomplete in various inventory subcommands, with the items relevants to it