### PR TITLE
fix: leaderboard item sort error and package-lock version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "falbot",
-	"version": "2.9.1",
+	"version": "2.9.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "falbot",
-			"version": "2.9.1",
+			"version": "2.9.2",
 			"license": "GNU 3.0",
 			"dependencies": {
 				"discord.js": "^14.9.0",

--- a/src/commands/leaderboard.js
+++ b/src/commands/leaderboard.js
@@ -147,7 +147,7 @@ module.exports = {
 				falcoins: 'falcoins',
 				rank: 'rank',
 				wins: 'vitorias',
-				item: `inventory.${interaction.options.getString('item')}`,
+				item: `inventory.${getItem(interaction.options.getString('item').toLowerCase())}`,
 				vote: 'voteStreak',
 			};
 
@@ -155,7 +155,7 @@ module.exports = {
 			const type = enums[subcommand];
 
 			if (subcommand === 'item') {
-				var item = getItem(interaction.options.getString('item').toLowerCase());
+				var item = type.split('.')[1];
 				var itemJSON = instance.items[item];
 
 				if (itemJSON === undefined) {


### PR DESCRIPTION
Closes #62 

## What does this PR do?

This pr fixes the leaderboard item sort error and also change the package-lock version to 2.9.2.
