### PR TITLE
fix: inventory worth calculation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -363,7 +363,7 @@ class Falbot {
 
 	getInventoryWorth(inventory) {
 		return Array.from(inventory).reduce((acc, [itemName, quantity]) => {
-			acc += this.items[itemName]['value'] * quantity;
+			if (this.items[itemName]['value'] !== undefined) acc += this.items[itemName]['value'] * quantity;
 			return acc;
 		}, 0);
 	}


### PR DESCRIPTION
## What does this PR do?
This PR fixes the inventory worth calculation when there is a Eternal Snowflake in the player's inventory