### PR TITLE
feat: improve inventory autocomplete

### DIFF
--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -299,6 +299,8 @@ module.exports = {
 						}`;
 						cost += items[key].value * amount;
 					}
+				} else {
+					cost = itemJSON.value * amount;
 				}
 
 				const embed = instance

--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -279,6 +279,7 @@ module.exports = {
 			} else if (type === 'calc') {
 				const amount = interaction.options.getInteger('amount');
 				const itemJSON = items[getItem(interaction.options.getString('item'))];
+				var cost = 0;
 
 				if (itemJSON === undefined) {
 					interaction.editReply({
@@ -296,6 +297,7 @@ module.exports = {
 						ingredients += `\n${items[key][interaction.locale] ?? items[key]['en-US']} x ${
 							itemJSON.recipe[key] * amount
 						}`;
+						cost += items[key].value * amount;
 					}
 				}
 
@@ -307,7 +309,7 @@ module.exports = {
 						value: `${ingredients != undefined ? ingredients : ''}\n${instance.getMessage(
 							interaction,
 							'COST'
-						)} **${format(itemJSON.value * amount)} falcoins**`,
+						)} **${format(cost)} falcoins**`,
 					});
 
 				interaction.editReply({
@@ -844,7 +846,7 @@ module.exports = {
 					(subcommand === 'craft' && itemData.recipe !== undefined) || // Craftable items
 					(subcommand === 'use' && itemData.use !== undefined) || // Usable items
 					(subcommand === 'sell' && itemData.mythical !== true) || // Sellable items
-					subcommand // Default case
+					subcommand === 'calc' // All items
 				) {
 					var item = itemData[interaction.locale] ?? itemData['en-US'];
 					return item.split(' ').slice(1).join(' ').toLowerCase();

--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -834,42 +834,25 @@ module.exports = {
 	autocomplete: async ({ interaction, instance }) => {
 		const focusedValue = interaction.options.getFocused().toLowerCase();
 		const items = instance.items;
-		if (interaction.options.getSubcommand() === 'equip') {
-			var localeItems = Object.keys(items)
-				.map((key) => {
-					if (items[key].equip === true) {
-						var item = items[key][interaction.locale] ?? items[key]['en-US'];
-						return item.split(' ').slice(1).join(' ').toLowerCase();
-					}
-					return undefined;
-				})
-				.filter((item) => item !== undefined);
-		} else if (interaction.options.getSubcommand() === 'craft') {
-			var localeItems = Object.keys(items)
-				.map((key) => {
-					if (items[key].recipe != undefined) {
-						var item = items[key][interaction.locale] ?? items[key]['en-US'];
-						return item.split(' ').slice(1).join(' ').toLowerCase();
-					}
-					return undefined;
-				})
-				.filter((item) => item !== undefined);
-		} else if (interaction.options.getSubcommand() === 'use') {
-			var localeItems = Object.keys(items)
-				.map((key) => {
-					if (items[key].use != undefined) {
-						var item = items[key][interaction.locale] ?? items[key]['en-US'];
-						return item.split(' ').slice(1).join(' ').toLowerCase();
-					}
-					return undefined;
-				})
-				.filter((item) => item !== undefined);
-		} else {
-			var localeItems = Object.keys(items).map((key) => {
-				var item = items[key][interaction.locale] ?? items[key]['en-US'];
-				return item.split(' ').slice(1).join(' ').toLowerCase();
-			});
-		}
+		const subcommand = interaction.options.getSubcommand();
+
+		var localeItems = Object.keys(items)
+			.map((key) => {
+				const itemData = items[key];
+				if (
+					(subcommand === 'equip' && itemData.equip === true) || // Equipable items
+					(subcommand === 'craft' && itemData.recipe !== undefined) || // Craftable items
+					(subcommand === 'use' && itemData.use !== undefined) || // Usable items
+					(subcommand === 'sell' && itemData.mythical !== true) || // Sellable items
+					subcommand // Default case
+				) {
+					var item = itemData[interaction.locale] ?? itemData['en-US'];
+					return item.split(' ').slice(1).join(' ').toLowerCase();
+				}
+				return undefined;
+			})
+			.filter((item) => item !== undefined);
+
 		const filtered = localeItems.filter((choice) => choice.startsWith(focusedValue));
 		await interaction.respond(filtered.map((choice) => ({ name: choice, value: choice })).slice(0, 25));
 	},


### PR DESCRIPTION
fixes #67 

## What does this PR do?
This PR fixes the bug that made eternal snowflake show up in the `/inventory sell` autocomplete

## Summary of changes
- Refactored the code for the inventory autocomplete, making the conditions more dynamic and easier to read
- Also fixed the inventory calc, making the cost be the sum of the ingredients cost if the item is craftable, or the item value if it's not