### PR TITLE
feat: create user stats system

### DIFF
--- a/src/commands/explore.js
+++ b/src/commands/explore.js
@@ -101,5 +101,10 @@ module.exports = {
 			embeds: [embed],
 			components: [buttons(['balance', 'inventory_view', 'cooldowns'])],
 		});
+
+		var stats = await readFile(interaction.user.id, 'stats');
+		stats.set('timesExplored', stats.get('timesExplored') + 1);
+		stats.set('itemsFound', stats.get('itemsFound') + total);
+		await changeDB(interaction.user.id, 'stats', stats, true);
 	},
 };

--- a/src/commands/fish.js
+++ b/src/commands/fish.js
@@ -101,5 +101,10 @@ module.exports = {
 			embeds: [embed],
 			components: [buttons(['balance', 'inventory_view', 'cooldowns'])],
 		});
+
+		var stats = await readFile(interaction.user.id, 'stats');
+		stats.set('timesFished', stats.get('timesFished') + 1);
+		stats.set('itemsFound', stats.get('itemsFound') + total);
+		await changeDB(interaction.user.id, 'stats', stats, true);
 	},
 };

--- a/src/commands/hunt.js
+++ b/src/commands/hunt.js
@@ -101,5 +101,10 @@ module.exports = {
 			embeds: [embed],
 			components: [buttons(['balance', 'inventory_view', 'cooldowns'])],
 		});
+
+		var stats = await readFile(interaction.user.id, 'stats');
+		stats.set('timesHunted', stats.get('timesHunted') + 1);
+		stats.set('itemsFound', stats.get('itemsFound') + total);
+		await changeDB(interaction.user.id, 'stats', stats, true);
 	},
 };

--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -601,6 +601,10 @@ module.exports = {
 					embeds: [embed],
 					components: [row],
 				});
+
+				var stats = await readFile(interaction.user.id, 'stats');
+				stats.set('itemsCrafted', stats.get('itemsCrafted') + amount);
+				await changeDB(interaction.user.id, 'stats', stats, true);
 			} else if (type === 'sellall') {
 				const embed = instance.createEmbed(member.displayColor).addFields({
 					name: instance.getMessage(interaction, 'SELLALL_TITLE'),

--- a/src/commands/mine.js
+++ b/src/commands/mine.js
@@ -101,5 +101,10 @@ module.exports = {
 			embeds: [embed],
 			components: [buttons(['balance', 'inventory_view', 'cooldowns'])],
 		});
+
+		var stats = await readFile(interaction.user.id, 'stats');
+		stats.set('timesMined', stats.get('timesMined') + 1);
+		stats.set('itemsFound', stats.get('itemsFound') + total);
+		await changeDB(interaction.user.id, 'stats', stats, true);
 	},
 };

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -1,0 +1,98 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { format, readFile } = require('../utils/functions.js');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('stats')
+		.setNameLocalization('pt-BR', 'estatísticas')
+		.setDescription("Shows your or another user's statistics")
+		.setDescriptionLocalization('pt-BR', 'Mostra as suas estatísticas ou a de outro usuário')
+		.setDMPermission(false)
+		.addUserOption((option) =>
+			option
+				.setName('user')
+				.setNameLocalization('pt-BR', 'usuário')
+				.setDescription('the user you want to get info about, leave blank to get your stats')
+				.setDescriptionLocalization(
+					'pt-BR',
+					'o usuário que você deseja ver as estatísticas, deixe vazio para ver a sua'
+				)
+				.setRequired(false)
+		),
+	execute: async ({ guild, member, instance, interaction }) => {
+		await interaction.deferReply().catch(() => {});
+		try {
+			var user = interaction.options.getUser('user');
+			const target = user ? await guild.members.fetch(user.id) : member;
+			const stats = await readFile(target.id, 'stats');
+			const rank_number = await readFile(target.id, 'rank');
+
+			const embed = instance
+				.createEmbed(target.displayColor)
+				.setTitle(instance.getMessage(interaction, 'STATS_TITLE', { USER: target.displayName }))
+				.addFields(
+					{
+						name: ':arrow_up: Rankups',
+						value: `${format(rank_number - 1)} rankups`,
+						inline: true,
+					},
+					{
+						name: `:pager: ${instance.getMessage(interaction, 'STATS_TOTAL_COMMANDS')}`,
+						value: `${format(stats.get('commands'))} ${instance.getMessage(interaction, 'STATS_COMMANDS')}`,
+						inline: true,
+					},
+					{
+						name: `:mag: ${instance.getMessage(interaction, 'STATS_ITEMS_FOUND')}`,
+						value: `${format(stats.get('itemsFound'))} ${instance.getMessage(interaction, 'STATS_ITEMS')}`,
+						inline: true,
+					},
+					{
+						name: `:briefcase: ${instance.getMessage(interaction, 'STATS_WORK')}`,
+						value: `${format(stats.get('timesWorked'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						inline: true,
+					},
+					{
+						name: `:compass: ${instance.getMessage(interaction, 'STATS_EXPLORE')}`,
+						value: `${format(stats.get('timesExplored'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						inline: true,
+					},
+					{
+						name: `:fishing_pole_and_fish: ${instance.getMessage(interaction, 'STATS_FISH')}`,
+						value: `${format(stats.get('timesFished'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						inline: true,
+					},
+					{
+						name: `:ox: ${instance.getMessage(interaction, 'STATS_HUNT')}`,
+						value: `${format(stats.get('timesHunted'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						inline: true,
+					},
+					{
+						name: `:pick: ${instance.getMessage(interaction, 'STATS_MINE')}`,
+						value: `${format(stats.get('timesMined'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						inline: true,
+					},
+					{
+						name: `:gift: ${instance.getMessage(interaction, 'STATS_VOTE')}`,
+						value: `${format(stats.get('timesVoted'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						inline: true,
+					},
+					{
+						name: `:hammer_pick: ${instance.getMessage(interaction, 'STATS_CRAFTS')}`,
+						value: `${format(stats.get('itemsCrafted'))} ${instance.getMessage(interaction, 'STATS_ITEMS')}`,
+						inline: true,
+					}
+				);
+
+			await interaction.editReply({
+				embeds: [embed],
+			});
+		} catch (error) {
+			console.error(`stats: ${error}`);
+			interaction.editReply({
+				content: instance.getMessage(interaction, 'EXCEPTION'),
+				embeds: [],
+				components: [],
+			});
+		}
+	},
+};

--- a/src/commands/vote.js
+++ b/src/commands/vote.js
@@ -46,6 +46,9 @@ module.exports = {
 									PERCENTAGE: bonus,
 							  }),
 				});
+				var stats = await readFile(interaction.user.id, 'stats');
+				stats.set('timesVoted', stats.get('timesVoted') + 1);
+				await changeDB(interaction.user.id, 'stats', stats, true);
 			} else if (voted && Date.now() - lastVote < 1000 * 60 * 60 * 12) {
 				var embed = instance.createEmbed(15158332).addFields({
 					name: instance.getMessage(interaction, 'ALREADY_COLLECTED'),

--- a/src/commands/work.js
+++ b/src/commands/work.js
@@ -48,6 +48,10 @@ module.exports = {
 			await interaction.editReply({
 				embeds: [embed],
 			});
+
+			var stats = await readFile(interaction.user.id, 'stats');
+			stats.set('timesWorked', stats.get('timesWorked') + 1);
+			await changeDB(interaction.user.id, 'stats', stats, true);
 		} catch (err) {
 			console.error(`work: ${err}`);
 			interaction.editReply({

--- a/src/events/interactions.js
+++ b/src/events/interactions.js
@@ -1,4 +1,4 @@
-const { resolveCooldown, msToTime, setCooldown } = require('../utils/functions.js');
+const { resolveCooldown, msToTime, setCooldown, changeDB, readFile } = require('../utils/functions.js');
 
 module.exports = {
 	name: 'interactionCreate',
@@ -69,6 +69,10 @@ module.exports = {
 				});
 			}
 
+			var stats = await readFile(interaction.user.id, 'stats');
+			stats.set('commands', stats.get('commands') + 1);
+			await changeDB(interaction.user.id, 'stats', stats, true);
+
 			command.execute({
 				interaction,
 				instance,
@@ -112,6 +116,10 @@ module.exports = {
 
 			if (commandName == 'help') interaction.values = [null];
 
+			var stats = await readFile(interaction.user.id, 'stats');
+			stats.set('commands', stats.get('commands') + 1);
+			await changeDB(interaction.user.id, 'stats', stats, true);
+
 			await command.execute({
 				interaction,
 				instance,
@@ -125,6 +133,11 @@ module.exports = {
 			});
 		} else if (interaction.isStringSelectMenu()) {
 			const command = client.commands.get(interaction.customId.split(' ')[0]);
+
+			var stats = await readFile(interaction.user.id, 'stats');
+			stats.set('commands', stats.get('commands') + 1);
+			await changeDB(interaction.user.id, 'stats', stats, true);
+
 			await command.execute({
 				guild: interaction.guild,
 				interaction,

--- a/src/schemas/user-schema.js
+++ b/src/schemas/user-schema.js
@@ -70,6 +70,22 @@ const userSchema = mongoose.Schema(
 			type: Number,
 			default: 0,
 		},
+		stats: {
+			type: Map,
+			of: Number,
+			default: new Map([
+				['ranks', 0],
+				['commands', 0],
+				['itemsFound', 0],
+				['timesWorked', 0],
+				['timesExplored', 0],
+				['timesFished', 0],
+				['timesHunted', 0],
+				['timesMined', 0],
+				['timesVoted', 0],
+				['itemsCrafted', 0],
+			]),
+		},
 	},
 	{
 		versionKey: false,

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1240,6 +1240,58 @@
 		"pt-BR": ":scroll: Lista de itens usáveis e seus efeitos",
 		"en-US": ":scroll: List of useable items and their effects"
 	},
+	"STATS_TITLE": {
+		"pt-BR": ":bar_chart: Estatísticas de {USER}",
+		"en-US": ":bar_chart: {USER}'s stats"
+	},
+	"STATS_COMMANDS": {
+		"pt-BR": "comandos usados",
+		"en-US": "commands used"
+	},
+	"STATS_ITEMS": {
+		"pt-BR": "itens",
+		"en-US": "items"
+	},
+	"STATS_TIMES": {
+		"pt-BR": "vezes",
+		"en-US": "times"
+	},
+	"STATS_TOTAL_COMMANDS": {
+		"pt-BR": "Comandos Totais",
+		"en-US": "Total Commands"
+	},
+	"STATS_ITEMS_FOUND": {
+		"pt-BR": "Itens Encontrados",
+		"en-US": "Items Found"
+	},
+	"STATS_WORK": {
+		"pt-BR": "Trabalhos",
+		"en-US": "Times Worked"
+	},
+	"STATS_EXPLORE": {
+		"pt-BR": "Explorações",
+		"en-US": "Times Explored"
+	},
+	"STATS_FISH": {
+		"pt-BR": "Pescarias",
+		"en-US": "Times Fished"
+	},
+	"STATS_MINE": {
+		"pt-BR": "Minerações",
+		"en-US": "Times Mined"
+	},
+	"STATS_HUNT": {
+		"pt-BR": "Caçadas",
+		"en-US": "Times Hunted"
+	},
+	"STATS_VOTE": {
+		"pt-BR": "Votos",
+		"en-US": "Times Voted"
+	},
+	"STATS_CRAFTS": {
+		"pt-BR": "Itens feitos",
+		"en-US": "Items crafted"
+	},
 	"1": {
 		"pt-BR": ":potato: Plebeu",
 		"en-US": ":potato: Peasent"


### PR DESCRIPTION
closes #64 

## What does this PR do?
This PR adds a user statistics system, with 10 initial statistics that are tracked globally

## Summary of changes
- stats command that shows the stats
- new stats map in user document
- 10 initial stats

## Media
![image](https://github.com/falcao-g/Falbot/assets/60127788/a0a74e82-ff94-4b41-83b5-52ba8c217b85)
