### PR TITLE
refactor: remove changeDB, readFile and createUser functions

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,10 +1,9 @@
-const { randint, changeDB, format } = require('./utils/functions.js');
-const { Client, GatewayIntentBits, Collection, EmbedBuilder, ActionRowBuilder, ButtonBuilder } = require('discord.js');
+const { randint, format } = require('./utils/functions.js');
+const { Client, GatewayIntentBits, Collection, EmbedBuilder } = require('discord.js');
 const path = require('path');
 require('dotenv').config();
 const { loadEvents } = require('./handlers/eventHandler.js');
 const { loadCommands } = require('./handlers/commandHandler.js');
-const databaseHandler = require('./handlers/databaseHandler.js');
 
 class Falbot {
 	config = require('./config.json');
@@ -12,6 +11,7 @@ class Falbot {
 	_banned = new Array();
 	_disabledChannels = new Map();
 	_disabledCommands = new Map();
+	database = require('./handlers/databaseHandler.js');
 	emojiList = {};
 	client = new Client({
 		shards: 'auto',
@@ -31,7 +31,7 @@ class Falbot {
 			console.log('Bot online');
 			this.client.on('error', console.error);
 
-			databaseHandler.connect();
+			this.database.connect();
 
 			this.client.events = new Collection();
 			this.client.commands = new Collection();
@@ -127,7 +127,9 @@ class Falbot {
 					}
 				}
 
-				await changeDB(winner.id, 'falcoins', lotto.prize);
+				const winnerFile = this.database.player.findOne(winner.id);
+				winnerFile.falcoins += lotto.prize;
+				winnerFile.save();
 
 				var winnerUser = await this.client.users.fetch(winner.id);
 

--- a/src/commands/economy/balance.js
+++ b/src/commands/economy/balance.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { format, readFile, buttons } = require('../../utils/functions.js');
+const { format, buttons } = require('../../utils/functions.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -28,14 +28,14 @@ module.exports = {
 				})
 				.setRequired(false)
 		),
-	execute: async ({ guild, member, instance, interaction }) => {
+	execute: async ({ guild, member, instance, interaction, database }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
 			if (interaction.options != undefined) {
 				var user = interaction.options.getUser('user');
 			}
 			const target = user ? await guild.members.fetch(user.id) : member;
-			const { rank, falcoins, vitorias, banco } = await readFile(target.user.id);
+			const { rank, falcoins, vitorias, banco } = await database.player.findOne(target.user.id);
 
 			const embed = instance
 				.createEmbed(target.displayColor)

--- a/src/commands/economy/contextBalance.js
+++ b/src/commands/economy/contextBalance.js
@@ -1,5 +1,5 @@
 const { ContextMenuCommandBuilder, ApplicationCommandType } = require('discord.js');
-const { format, readFile, buttons } = require('../../utils/functions.js');
+const { format, buttons } = require('../../utils/functions.js');
 
 module.exports = {
 	data: new ContextMenuCommandBuilder()
@@ -10,11 +10,11 @@ module.exports = {
 		})
 		.setType(ApplicationCommandType.User)
 		.setDMPermission(false),
-	execute: async ({ instance, interaction }) => {
+	execute: async ({ instance, interaction, database }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
 			const target = interaction.targetMember;
-			const { rank, falcoins, vitorias, banco } = await readFile(target.user.id);
+			const { rank, falcoins, vitorias, banco } = await database.player.findOne(target.user.id);
 
 			const embed = instance
 				.createEmbed(target.displayColor)

--- a/src/commands/economy/contextProfile.js
+++ b/src/commands/economy/contextProfile.js
@@ -1,5 +1,5 @@
 const { ContextMenuCommandBuilder, ApplicationCommandType, time } = require('discord.js');
-const { format, readFile, buttons } = require('../../utils/functions.js');
+const { format, buttons } = require('../../utils/functions.js');
 
 module.exports = {
 	data: new ContextMenuCommandBuilder()
@@ -10,13 +10,12 @@ module.exports = {
 		})
 		.setType(ApplicationCommandType.User)
 		.setDMPermission(false),
-	execute: async ({ instance, interaction }) => {
+	execute: async ({ instance, interaction, database }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
 			const target = interaction.targetMember;
-			const { rank, falcoins, vitorias, banco, inventory, voteStreak, tickets, createdAt } = await readFile(
-				target.user.id
-			);
+			const { rank, falcoins, vitorias, banco, inventory, voteStreak, tickets, createdAt } =
+				await database.player.findOne(target.user.id);
 			const limit = instance.levels[rank - 1].bankLimit;
 			const items = instance.items;
 

--- a/src/commands/economy/cooldowns.js
+++ b/src/commands/economy/cooldowns.js
@@ -1,5 +1,5 @@
 const { ButtonBuilder, ActionRowBuilder, SlashCommandBuilder } = require('discord.js');
-const { readFile, msToTime, resolveCooldown } = require('../../utils/functions.js');
+const { msToTime, resolveCooldown } = require('../../utils/functions.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -14,10 +14,11 @@ module.exports = {
 			'es-ES': 'Muestra el tiempo que falta para poder usar ciertos comandos',
 		})
 		.setDMPermission(false),
-	execute: async ({ interaction, instance, member }) => {
+	execute: async ({ interaction, instance, member, database }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
-			const voteCooldown = Date.now() - (await readFile(member.id, 'lastVote'));
+			const { lastVote } = await database.player.findOne(member.id);
+			const voteCooldown = Date.now() - lastVote;
 			const scratchCooldown = await resolveCooldown(member.id, 'scratch');
 			const workCooldown = await resolveCooldown(member.id, 'work');
 			const fishCooldown = await resolveCooldown(member.id, 'fish');

--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -1,4 +1,4 @@
-const { readFile, changeDB, randint, pick, isEquipped, useItem, buttons } = require('../../utils/functions.js');
+const { randint, pick, isEquipped, useItem, buttons } = require('../../utils/functions.js');
 const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
@@ -15,14 +15,12 @@ module.exports = {
 			'es-ES': 'Ve a explorar para conseguir items',
 		})
 		.setDMPermission(false),
-	execute: async ({ interaction, instance, member }) => {
+	execute: async ({ interaction, instance, member, database }) => {
 		await interaction.deferReply().catch(() => {});
 		const items = instance.items;
-		const inventory = await readFile(member.id, 'inventory');
-		const limit =
-			instance.levels[(await readFile(member.id, 'rank')) - 1].inventoryLimit +
-			(await readFile(member.id, 'inventoryBonus'));
-		const inventoryWorth = instance.getInventoryWorth(inventory);
+		const player = await database.player.findOne(member.id);
+		const limit = instance.levels[player.rank - 1].inventoryLimit + player.inventoryBonus;
+		const inventoryWorth = instance.getInventoryWorth(player.inventory);
 		var buff = 1;
 		var buffText = '';
 
@@ -94,11 +92,9 @@ module.exports = {
 			total += amount;
 			text += `**${name}** x ${amount}\n`;
 			filteredItems = filteredItems.filter((item) => item[0] !== selectedItem);
-			inventory.set(selectedItem, (inventory.get(selectedItem) || 0) + amount);
+			player.inventory.set(selectedItem, (player.inventory.get(selectedItem) || 0) + amount);
 			selectedItems.push(selectedItem);
 		}
-
-		await changeDB(member.id, 'inventory', inventory, true);
 
 		var embed = instance.createEmbed(member.displayColor).addFields({
 			name:
@@ -114,9 +110,8 @@ module.exports = {
 			components: [buttons(['balance', 'inventory_view', 'cooldowns'])],
 		});
 
-		var stats = await readFile(interaction.user.id, 'stats');
-		stats.set('timesExplored', stats.get('timesExplored') + 1);
-		stats.set('itemsFound', stats.get('itemsFound') + total);
-		await changeDB(interaction.user.id, 'stats', stats, true);
+		player.stats.set('timesExplored', player.stats.get('timesExplored') + 1);
+		player.stats.set('itemsFound', player.stats.get('itemsFound') + total);
+		player.save();
 	},
 };

--- a/src/commands/economy/fight.js
+++ b/src/commands/economy/fight.js
@@ -42,11 +42,11 @@ module.exports = {
 		await interaction.deferReply().catch(() => {});
 		try {
 			const falcoins = interaction.options.getString('falcoins');
-			var member2 = await guild.members.fetch(interaction.options.getUser('user').id);
+			var challenged = await guild.members.fetch(interaction.options.getUser('user').id);
 			const author = await database.player.findOne(user.id);
-			const challenged = await database.player.findOne(member2.id);
+			const challengedFile = await database.player.findOne(challenged.id);
 
-			if (member2.user === user) {
+			if (challenged.user === user) {
 				instance.editReply(interaction, {
 					content: instance.getMessage(interaction, 'NAO_JOGAR_SOZINHO'),
 				});
@@ -63,11 +63,11 @@ module.exports = {
 				});
 				return;
 			}
-			if (author.falcoins >= bet && challenged.falcoins >= bet) {
+			if (author.falcoins >= bet && challengedFile.falcoins >= bet) {
 				var answer = await instance.editReply(interaction, {
 					content: instance.getMessage(interaction, 'LUTA_CONVITE', {
 						USER: member,
-						USER2: member2,
+						USER2: challenged,
 						FALCOINS: format(bet),
 					}),
 					components: [buttons(['accept', 'refuse'])],
@@ -75,7 +75,7 @@ module.exports = {
 				});
 
 				const filter = (btInt) => {
-					return instance.defaultFilter(btInt) && btInt.user.id === member2.user.id;
+					return instance.defaultFilter(btInt) && btInt.user.id === challenged.user.id;
 				};
 
 				const collector = answer.createMessageComponentCollector({
@@ -88,18 +88,18 @@ module.exports = {
 					if (collected.size === 0) {
 						interaction.followUp({
 							content: instance.getMessage(interaction, 'LUTA_CANCELADO_DEMOROU', {
-								USER: member2,
+								USER: challenged,
 							}),
 						});
 					} else if (collected.first().customId === 'refuse') {
 						interaction.followUp({
 							content: instance.getMessage(interaction, 'LUTA_CANCELADO_RECUSOU', {
-								USER: member2,
+								USER: challenged,
 							}),
 						});
 					} else {
 						author.falcoins -= bet;
-						challenged.falcoins -= bet;
+						challengedFile.falcoins -= bet;
 						const attacks = ['instantâneo', 'stun', 'roubo de vida', 'cura', 'self', 'escudo'];
 						const player_1 = {
 							hp: 100,
@@ -111,10 +111,10 @@ module.exports = {
 						};
 						const player_2 = {
 							hp: 100,
-							name: member2.displayName,
+							name: challenged.displayName,
 							stunned: false,
-							mention: member2,
-							id: member2.id,
+							mention: challenged,
+							id: challenged.id,
 							escudo: false,
 						};
 						const luck = Math.round(Math.random());
@@ -238,7 +238,7 @@ module.exports = {
 				});
 			}
 			author.save();
-			challenged.save();
+			challengedFile.save();
 		} catch (error) {
 			console.error(`fight: ${error}`);
 			interaction.channel

--- a/src/commands/economy/horse.js
+++ b/src/commands/economy/horse.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { specialArg, readFile, randint, changeDB, format } = require('../../utils/functions.js');
+const { specialArg, randint, format } = require('../../utils/functions.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -42,18 +42,17 @@ module.exports = {
 					'the amount of falcoins you want to bet (supports "all"/"half" and things like 50.000, 20%, 10M, 25B)'
 				)
 				.setDescriptionLocalizations({
-					'pt-BR':
-						'a quantidade de falcoins que você quer apostar (suporta "tudo"/"metade" e notas como 50.000, 20%, 10M, 25B)',
-					'es-ES':
-						'la cantidad de falcoins que quieres apostar (soporta "todo"/"mitad" y notas como 50.000, 20%, 10M, 25B)',
+					'pt-BR': 'a quantidade de falcoins para apostar (suporta "tudo"/"metade" e notas como 50.000, 20%, 10M, 25B)',
+					'es-ES': 'la cantidad de falcoins para apostar (soporta "todo"/"mitad" y notas como 50.000, 20%, 10M, 25B)',
 				})
 				.setRequired(true)
 		),
-	execute: async ({ interaction, user, instance, member }) => {
+	execute: async ({ interaction, user, instance, member, database }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
 			const horse = interaction.options.getString('horse');
 			const falcoins = interaction.options.getString('falcoins');
+			const player = await database.player.findOne(user.id);
 			try {
 				var bet = await specialArg(falcoins, user.id, 'falcoins');
 			} catch {
@@ -64,8 +63,8 @@ module.exports = {
 				});
 				return;
 			}
-			if ((await readFile(user.id, 'falcoins')) >= bet) {
-				await changeDB(user.id, 'falcoins', -bet);
+			if (player.falcoins >= bet) {
+				player.falcoins -= bet;
 				const horses = ['- - - - -', '- - - - -', '- - - - -', '- - - - -', '- - - - -'];
 				const embed = instance
 					.createEmbed(member.displayColor)
@@ -105,13 +104,13 @@ module.exports = {
 				}
 
 				if (horse == winner) {
-					await changeDB(user.id, 'falcoins', bet * 5);
+					player.falcoins += bet * 5;
 					embed.setColor(3066993).setDescription(
 						instance.getMessage(interaction, 'CAVALO_DESCRIPTION_WON', {
 							BET: format(bet),
 							HORSE: horse,
 							FALCOINS: format(bet * 5),
-							SALDO: await readFile(user.id, 'falcoins', true),
+							SALDO: format(player.falcoins),
 						})
 					);
 				} else {
@@ -119,7 +118,7 @@ module.exports = {
 						instance.getMessage(interaction, 'CAVALO_DESCRIPTION_LOST', {
 							BET: format(bet),
 							HORSE: horse,
-							SALDO: await readFile(user.id, 'falcoins', true),
+							SALDO: format(player.falcoins),
 						})
 					);
 				}
@@ -132,6 +131,7 @@ module.exports = {
 					content: instance.getMessage(interaction, 'FALCOINS_INSUFICIENTES'),
 				});
 			}
+			player.save();
 		} catch (error) {
 			console.error(`horse: ${error}`);
 			instance.editReply(interaction, {

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -1,4 +1,4 @@
-const { readFile, changeDB, randint, pick, isEquipped, useItem, buttons } = require('../../utils/functions.js');
+const { randint, pick, isEquipped, useItem, buttons } = require('../../utils/functions.js');
 const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
@@ -15,14 +15,12 @@ module.exports = {
 			'es-ES': 'Ve a cazar para conseguir items',
 		})
 		.setDMPermission(false),
-	execute: async ({ interaction, instance, member }) => {
+	execute: async ({ interaction, instance, member, database }) => {
 		await interaction.deferReply().catch(() => {});
 		const items = instance.items;
-		const inventory = await readFile(member.id, 'inventory');
-		const limit =
-			instance.levels[(await readFile(member.id, 'rank')) - 1].inventoryLimit +
-			(await readFile(member.id, 'inventoryBonus'));
-		const inventoryWorth = instance.getInventoryWorth(inventory);
+		const player = await database.player.findOne(member.id);
+		const limit = instance.levels[player.rank - 1].inventoryLimit + player.inventoryBonus;
+		const inventoryWorth = instance.getInventoryWorth(player.inventory);
 		var buff = 1;
 		var buffText = '';
 
@@ -94,11 +92,9 @@ module.exports = {
 			total += amount;
 			text += `**${name}** x ${amount}\n`;
 			filteredItems = filteredItems.filter((item) => item[0] !== selectedItem);
-			inventory.set(selectedItem, (inventory.get(selectedItem) || 0) + amount);
+			player.inventory.set(selectedItem, (player.inventory.get(selectedItem) || 0) + amount);
 			selectedItems.push(selectedItem);
 		}
-
-		await changeDB(member.id, 'inventory', inventory, true);
 
 		var embed = instance.createEmbed(member.displayColor).addFields({
 			name:
@@ -114,9 +110,8 @@ module.exports = {
 			components: [buttons(['balance', 'inventory_view', 'cooldowns'])],
 		});
 
-		var stats = await readFile(interaction.user.id, 'stats');
-		stats.set('timesHunted', stats.get('timesHunted') + 1);
-		stats.set('itemsFound', stats.get('itemsFound') + total);
-		await changeDB(interaction.user.id, 'stats', stats, true);
+		player.stats.set('timesHunted', player.stats.get('timesHunted') + 1);
+		player.stats.set('itemsFound', player.stats.get('itemsFound') + total);
+		player.save();
 	},
 };

--- a/src/commands/economy/item.js
+++ b/src/commands/economy/item.js
@@ -1,4 +1,4 @@
-const { format, getItem, readFile } = require('../../utils/functions.js');
+const { format, getItem } = require('../../utils/functions.js');
 const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder } = require('discord.js');
 
 module.exports = {
@@ -21,10 +21,11 @@ module.exports = {
 				.setRequired(true)
 				.setAutocomplete(true)
 		),
-	execute: async ({ interaction, instance, member, subcommand, args }) => {
+	execute: async ({ interaction, instance, member, subcommand, args, database }) => {
 		try {
 			await interaction.deferReply().catch(() => {});
 			const items = instance.items;
+			const player = await database.player.findOne(member.id);
 
 			if (interaction.options !== undefined) {
 				var item = interaction.options.getString('item');
@@ -45,7 +46,6 @@ module.exports = {
 
 			const itemKey = getItem(item);
 			const itemJSON = items[itemKey];
-			const inventory = await readFile(member.id, 'inventory');
 
 			if (itemJSON === undefined) {
 				instance.editReply(interaction, {
@@ -86,9 +86,9 @@ module.exports = {
 				information += `\n${instance.getMessage(interaction, itemJSON.effect.toUpperCase())}`;
 			}
 
-			if (inventory.get(itemKey))
+			if (player.inventory.get(itemKey))
 				information += `\n${instance.getMessage(interaction, 'OWNED', {
-					AMOUNT: inventory.get(itemKey),
+					AMOUNT: player.inventory.get(itemKey),
 				})}`;
 
 			const embed = instance

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -1,4 +1,4 @@
-const { readFile, changeDB, randint, pick, isEquipped, useItem, buttons } = require('../../utils/functions.js');
+const { randint, pick, isEquipped, useItem, buttons } = require('../../utils/functions.js');
 const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
@@ -15,14 +15,12 @@ module.exports = {
 			'es-ES': 'Ve a minar para conseguir objetos',
 		})
 		.setDMPermission(false),
-	execute: async ({ interaction, instance, member }) => {
+	execute: async ({ interaction, instance, member, database }) => {
 		await interaction.deferReply().catch(() => {});
 		const items = instance.items;
-		const inventory = await readFile(member.id, 'inventory');
-		const limit =
-			instance.levels[(await readFile(member.id, 'rank')) - 1].inventoryLimit +
-			(await readFile(member.id, 'inventoryBonus'));
-		const inventoryWorth = instance.getInventoryWorth(inventory);
+		const player = await database.player.findOne(member.id);
+		const limit = instance.levels[player.rank - 1].inventoryLimit + player.inventoryBonus;
+		const inventoryWorth = instance.getInventoryWorth(player.inventory);
 		var buff = 1;
 		var buffText = '';
 
@@ -94,11 +92,9 @@ module.exports = {
 			total += amount;
 			text += `**${name}** x ${amount}\n`;
 			filteredItems = filteredItems.filter((item) => item[0] !== selectedItem);
-			inventory.set(selectedItem, (inventory.get(selectedItem) || 0) + amount);
+			player.inventory.set(selectedItem, (player.inventory.get(selectedItem) || 0) + amount);
 			selectedItems.push(selectedItem);
 		}
-
-		await changeDB(member.id, 'inventory', inventory, true);
 
 		var embed = instance.createEmbed(member.displayColor).addFields({
 			name:
@@ -114,9 +110,8 @@ module.exports = {
 			components: [buttons(['balance', 'inventory_view', 'cooldowns'])],
 		});
 
-		var stats = await readFile(interaction.user.id, 'stats');
-		stats.set('timesMined', stats.get('timesMined') + 1);
-		stats.set('itemsFound', stats.get('itemsFound') + total);
-		await changeDB(interaction.user.id, 'stats', stats, true);
+		player.stats.set('timesMined', player.stats.get('timesMined') + 1);
+		player.stats.set('itemsFound', player.stats.get('itemsFound') + total);
+		player.save();
 	},
 };

--- a/src/commands/economy/profile.js
+++ b/src/commands/economy/profile.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, time } = require('discord.js');
-const { format, readFile, buttons } = require('../../utils/functions.js');
+const { format, buttons } = require('../../utils/functions.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -28,16 +28,14 @@ module.exports = {
 				})
 				.setRequired(false)
 		),
-	execute: async ({ guild, member, instance, interaction }) => {
+	execute: async ({ guild, member, instance, interaction, database }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
 			const user = interaction.options.getUser('user');
 			const target = user ? await guild.members.fetch(user.id) : member;
-			const { rank, falcoins, vitorias, banco, inventory, voteStreak, tickets, createdAt } = await readFile(
-				target.user.id
-			);
+			const { rank, falcoins, vitorias, banco, inventory, voteStreak, tickets, createdAt } =
+				await database.player.findOne(target.user.id);
 			const limit = instance.levels[rank - 1].bankLimit;
-			const items = instance.items;
 
 			if (instance.levels[rank - 1].falcoinsToLevelUp === undefined) {
 				var rankText = ':sparkles: ' + instance.getMessage(interaction, 'MAX_RANK2');

--- a/src/commands/economy/scratch.js
+++ b/src/commands/economy/scratch.js
@@ -15,10 +15,11 @@ module.exports = {
 			'es-ES': 'Juega raspadinha para una oportunidad de ganar muchos falcoins',
 		})
 		.setDMPermission(false),
-	execute: async ({ interaction, instance, user, member }) => {
+	execute: async ({ interaction, instance, user, member, database }) => {
 		try {
 			await interaction.deferReply().catch(() => {});
 
+			const player = await database.player.findOne(user.id);
 			const row = new ActionRowBuilder();
 			const row2 = new ActionRowBuilder();
 			const row3 = new ActionRowBuilder();
@@ -63,7 +64,7 @@ module.exports = {
 				if (luck === 25) {
 					//jackpot
 					amount = randint(200000, 300000);
-					await changeDB(user.id, 'falcoins', amount);
+					player.falcoins += amount;
 					embed.setColor(15844367).addFields({
 						name: instance.getMessage(interaction, 'SCRATCH_PRIZE'),
 						value: `${instance.getMessage(interaction, 'SCRATCH_PRIZE_DESCRIPTION', {
@@ -76,7 +77,7 @@ module.exports = {
 				} else if (luck === 24) {
 					//super close
 					amount = randint(100000, 190000);
-					await changeDB(user.id, 'falcoins', amount);
+					player.falcoins += amount;
 					embed.setColor(3066993).addFields({
 						name: instance.getMessage(interaction, 'SCRATCH_SUPER'),
 						value: `${instance.getMessage(interaction, 'SCRATCH_SUPER_DESCRIPTION', {
@@ -89,7 +90,7 @@ module.exports = {
 				} else if (luck === 23 || luck === 22) {
 					//pretty close
 					amount = randint(50000, 90000);
-					await changeDB(user.id, 'falcoins', amount);
+					player.falcoins += amount;
 					embed.setColor(3066993).addFields({
 						name: instance.getMessage(interaction, 'SCRATCH_PRETTY'),
 						value: `${instance.getMessage(interaction, 'SCRATCH_PRETTY_DESCRIPTION', {
@@ -102,7 +103,7 @@ module.exports = {
 				} else if (luck === 21 || luck === 20) {
 					//kinda close
 					amount = randint(30000, 45000);
-					await changeDB(user.id, 'falcoins', amount);
+					player.falcoins += amount;
 					embed.setColor(3066993).addFields({
 						name: instance.getMessage(interaction, 'SCRATCH_KINDOF'),
 						value: `${instance.getMessage(interaction, 'SCRATCH_KINDOF_DESCRIPTION', {
@@ -115,7 +116,7 @@ module.exports = {
 					embed.setColor(15158332);
 					if (randint(1, 100) >= 80) {
 						amount = randint(10000, 20000);
-						await changeDB(user.id, 'falcoins', amount);
+						player.falcoins += amount;
 						embed.addFields({
 							name: 'Meh...',
 							value: `${instance.getMessage(interaction, 'SCRATCH_LOSE_DESCRIPTION2', {
@@ -146,6 +147,7 @@ module.exports = {
 					});
 				}
 			});
+			collector.on('end', () => player.save());
 		} catch (error) {
 			console.error(`scratch: ${error}`);
 			instance.editReply(interaction, {

--- a/src/commands/economy/stats.js
+++ b/src/commands/economy/stats.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { format, readFile } = require('../../utils/functions.js');
+const { format } = require('../../utils/functions.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -28,13 +28,12 @@ module.exports = {
 				})
 				.setRequired(false)
 		),
-	execute: async ({ guild, member, instance, interaction }) => {
+	execute: async ({ guild, member, instance, interaction, database }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
 			var user = interaction.options.getUser('user');
 			const target = user ? await guild.members.fetch(user.id) : member;
-			const stats = await readFile(target.id, 'stats');
-			const rank_number = await readFile(target.id, 'rank');
+			const player = await database.player.findOne(target.id);
 
 			const embed = instance
 				.createEmbed(target.displayColor)
@@ -42,52 +41,52 @@ module.exports = {
 				.addFields(
 					{
 						name: ':arrow_up: Rankups',
-						value: `${format(rank_number - 1)} rankups`,
+						value: `${format(player.rank - 1)} rankups`,
 						inline: true,
 					},
 					{
 						name: `:pager: ${instance.getMessage(interaction, 'STATS_TOTAL_COMMANDS')}`,
-						value: `${format(stats.get('commands'))} ${instance.getMessage(interaction, 'STATS_COMMANDS')}`,
+						value: `${format(player.stats.get('commands'))} ${instance.getMessage(interaction, 'STATS_COMMANDS')}`,
 						inline: true,
 					},
 					{
 						name: `:mag: ${instance.getMessage(interaction, 'STATS_ITEMS_FOUND')}`,
-						value: `${format(stats.get('itemsFound'))} ${instance.getMessage(interaction, 'STATS_ITEMS')}`,
+						value: `${format(player.stats.get('itemsFound'))} ${instance.getMessage(interaction, 'STATS_ITEMS')}`,
 						inline: true,
 					},
 					{
 						name: `:briefcase: ${instance.getMessage(interaction, 'STATS_WORK')}`,
-						value: `${format(stats.get('timesWorked'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						value: `${format(player.stats.get('timesWorked'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
 						inline: true,
 					},
 					{
 						name: `:compass: ${instance.getMessage(interaction, 'STATS_EXPLORE')}`,
-						value: `${format(stats.get('timesExplored'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						value: `${format(player.stats.get('timesExplored'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
 						inline: true,
 					},
 					{
 						name: `:fishing_pole_and_fish: ${instance.getMessage(interaction, 'STATS_FISH')}`,
-						value: `${format(stats.get('timesFished'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						value: `${format(player.stats.get('timesFished'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
 						inline: true,
 					},
 					{
 						name: `:ox: ${instance.getMessage(interaction, 'STATS_HUNT')}`,
-						value: `${format(stats.get('timesHunted'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						value: `${format(player.stats.get('timesHunted'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
 						inline: true,
 					},
 					{
 						name: `:pick: ${instance.getMessage(interaction, 'STATS_MINE')}`,
-						value: `${format(stats.get('timesMined'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						value: `${format(player.stats.get('timesMined'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
 						inline: true,
 					},
 					{
 						name: `:gift: ${instance.getMessage(interaction, 'STATS_VOTE')}`,
-						value: `${format(stats.get('timesVoted'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
+						value: `${format(player.stats.get('timesVoted'))} ${instance.getMessage(interaction, 'STATS_TIMES')}`,
 						inline: true,
 					},
 					{
 						name: `:hammer_pick: ${instance.getMessage(interaction, 'STATS_CRAFTS')}`,
-						value: `${format(stats.get('itemsCrafted'))} ${instance.getMessage(interaction, 'STATS_ITEMS')}`,
+						value: `${format(player.stats.get('itemsCrafted'))} ${instance.getMessage(interaction, 'STATS_ITEMS')}`,
 						inline: true,
 					}
 				);

--- a/src/database/player.js
+++ b/src/database/player.js
@@ -1,11 +1,23 @@
 const userSchema = require('../schemas/user-schema.js');
 
 module.exports = {
+	/**
+	 *
+	 * @param {Snowflake} id
+	 * @description Finds a user in the database and if it doesn't exist, creates it
+	 * @returns {Promise<object>}
+	 */
 	async findOne(id) {
 		await this.create(id);
 		const result = await userSchema.findOne({ _id: id });
 		return result;
 	},
+	/**
+	 *
+	 * @param {Snowflake} id
+	 * @description Creates a user in the database
+	 * @returns {Promise<void>}
+	 */
 	async create(id) {
 		await userSchema.findByIdAndUpdate(
 			id,

--- a/src/database/player.js
+++ b/src/database/player.js
@@ -1,0 +1,20 @@
+const userSchema = require('../schemas/user-schema.js');
+
+module.exports = {
+	async findOne(id) {
+		await this.create(id);
+		const result = await userSchema.findOne({ _id: id });
+		return result;
+	},
+	async create(id) {
+		await userSchema.findByIdAndUpdate(
+			id,
+			{
+				_id: id,
+			},
+			{
+				upsert: true,
+			}
+		);
+	},
+};

--- a/src/events/interactions.js
+++ b/src/events/interactions.js
@@ -1,4 +1,4 @@
-const { resolveCooldown, msToTime, setCooldown, changeDB, readFile } = require('../utils/functions.js');
+const { resolveCooldown, msToTime, setCooldown } = require('../utils/functions.js');
 
 module.exports = {
 	name: 'interactionCreate',
@@ -69,9 +69,9 @@ module.exports = {
 				});
 			}
 
-			var stats = await readFile(interaction.user.id, 'stats');
-			stats.set('commands', stats.get('commands') + 1);
-			await changeDB(interaction.user.id, 'stats', stats, true);
+			const player = await instance.database.player.findOne(interaction.user.id);
+			player.stats.set('commands', player.stats.get('commands') + 1);
+			player.save();
 
 			command.execute({
 				interaction,
@@ -81,6 +81,7 @@ module.exports = {
 				guild: interaction.guild,
 				user: interaction.user,
 				channel: interaction.channel,
+				database: instance.database,
 			});
 		} else if (interaction.isAutocomplete()) {
 			const command = client.commands.get(interaction.commandName);
@@ -116,9 +117,9 @@ module.exports = {
 
 			if (commandName == 'help') interaction.values = [null];
 
-			var stats = await readFile(interaction.user.id, 'stats');
-			stats.set('commands', stats.get('commands') + 1);
-			await changeDB(interaction.user.id, 'stats', stats, true);
+			const player = await instance.database.player.findOne(interaction.user.id);
+			player.stats.set('commands', player.stats.get('commands') + 1);
+			player.save();
 
 			await command.execute({
 				interaction,
@@ -128,15 +129,16 @@ module.exports = {
 				guild: interaction.guild,
 				user: interaction.user,
 				channel: interaction.channel,
+				database: instance.database,
 				subcommand,
 				args: interaction.customId.split(' ').slice(2),
 			});
 		} else if (interaction.isStringSelectMenu()) {
 			const command = client.commands.get(interaction.customId.split(' ')[0]);
 
-			var stats = await readFile(interaction.user.id, 'stats');
-			stats.set('commands', stats.get('commands') + 1);
-			await changeDB(interaction.user.id, 'stats', stats, true);
+			const player = await instance.database.player.findOne(interaction.user.id);
+			player.stats.set('commands', player.stats.get('commands') + 1);
+			player.save();
 
 			await command.execute({
 				guild: interaction.guild,
@@ -146,6 +148,7 @@ module.exports = {
 				client,
 				user: interaction.user,
 				channel: interaction.channel,
+				database: instance.database,
 				subcommand: interaction.customId.split(' ')[1],
 			});
 		}

--- a/src/handlers/databaseHandler.js
+++ b/src/handlers/databaseHandler.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 require('dotenv').config();
 
 class databaseHandler {
+	player = require('../database/player.js');
+
 	async connect() {
 		try {
 			mongoose.set('strictQuery', false);

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,60 +1,6 @@
 const userSchema = require('../schemas/user-schema');
 const { ActionRowBuilder, ButtonBuilder, GuildMember } = require('discord.js');
 const items = require('./json/items.json');
-
-/**
- *
- * @param {DiscordID} id
- * @description Creates a new user in the database if it doesn't exist
- * @async
- * @returns {Promise<void>}
- */
-async function createUser(id) {
-	try {
-		await userSchema.findByIdAndUpdate(
-			id,
-			{
-				_id: id,
-			},
-			{
-				upsert: true,
-			}
-		);
-	} catch (error) {
-		console.error(`Erro ao criar usuário: ${error}`);
-	}
-}
-
-/**
- *
- * @param {DiscordID} id
- * @param {string} field
- * @param {integer} quantity
- * @param {boolean} erase
- * @description Changes the value of a user's document field in the database
- * @example changeDB(id, 'falcoins', 1000, false) // Adds 1000 falcoins to the user
- * @async
- * @returns {Promise<void>}
- */
-async function changeDB(id, field, quantity = 1, erase = false) {
-	try {
-		await createUser(id);
-		if (erase == true) {
-			await userSchema.findByIdAndUpdate(id, {
-				[field]: quantity,
-			});
-		} else {
-			await userSchema.findByIdAndUpdate(id, {
-				$inc: {
-					[field]: quantity,
-				},
-			});
-		}
-	} catch (error) {
-		console.error(`Erro ao mudar a database: ${error}`);
-	}
-}
-
 /**
  * @param {integer} ms
  * @description Converts milliseconds to a string with the format "1m 1d 1h 1m 1s"
@@ -177,32 +123,6 @@ function format(falcoins) {
 
 /**
  *
- * @param {DiscordID} id
- * @param {string} field
- * @param {boolean} rich
- * @description Reads a user's document field in the database
- * @async
- * @example readFile(id, 'falcoins', true) // 1.000.000
- * @returns <Promise<any>
- */
-async function readFile(id, field = '', rich = false) {
-	try {
-		await createUser(id);
-
-		if (field == '') {
-			return await userSchema.findById(id);
-		} else if (rich == false) {
-			return (await userSchema.findById(id))[field];
-		} else {
-			return await format((await userSchema.findById(id))[field]);
-		}
-	} catch (error) {
-		console.error(`Erro ao ler arquivo: ${error}`);
-	}
-}
-
-/**
- *
  * @param {integer} low
  * @param {integer} high
  * @description Generates a random integer between low and high
@@ -286,7 +206,7 @@ function pick(data) {
 async function setCooldown(id, command, cooldown) {
 	var cooldowns = (await userSchema.findById(id)).cooldowns;
 	cooldowns.set(command, Date.now() + cooldown * 1000);
-	await changeDB(id, 'cooldowns', cooldowns, true);
+	await userSchema.findByIdAndUpdate(id, { cooldowns: cooldowns });
 }
 
 /**
@@ -306,7 +226,7 @@ async function resolveCooldown(id, command) {
 			return commandField - Date.now();
 		} else {
 			cooldowns.set(command, 0);
-			await changeDB(id, 'cooldowns', cooldowns, true);
+			await userSchema.findByIdAndUpdate(id, { cooldowns: cooldowns });
 		}
 	}
 	return 0;
@@ -374,7 +294,7 @@ function buttons(buttons) {
  * @returns {boolean}
  */
 async function isEquipped(member, item) {
-	const equippedItems = await readFile(member.id, 'equippedItems');
+	const equippedItems = (await userSchema.findById(member.id)).equippedItems;
 
 	for (itemEquipped of equippedItems) {
 		if (itemEquipped.name === item) {
@@ -393,7 +313,7 @@ async function isEquipped(member, item) {
  * @returns {Promise<void>}
  */
 async function useItem(member, item) {
-	var equippedItems = await readFile(member.id, 'equippedItems');
+	var equippedItems = (await userSchema.findById(member.id)).equippedItems;
 
 	for (itemEquipped of equippedItems) {
 		if (itemEquipped.name === item) {
@@ -406,16 +326,13 @@ async function useItem(member, item) {
 		}
 	}
 
-	await changeDB(member.id, 'equippedItems', equippedItems, true);
+	await userSchema.findByIdAndUpdate(member.id, { equippedItems: equippedItems });
 }
 
 module.exports = {
-	createUser,
-	changeDB,
 	msToTime,
 	specialArg,
 	format,
-	readFile,
 	randint,
 	paginate,
 	pick,

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -51,7 +51,6 @@ function msToTime(ms) {
  * @returns {Promise<integer>}
  */
 async function specialArg(arg, id, field = 'falcoins') {
-	await createUser(id);
 	var user = await userSchema.findById(id);
 
 	arg = arg.toString();


### PR DESCRIPTION
## What does this PR do?
This pr removes the changeDB, readFile and createUser functions in favor of a more clean database manipulation

## Summary of changes
- removes changeDB, readFile and createUser
- creates a database folder where database manipulation files are stored
- creates a player.js file in the database folder with the functions findOne and create
- use those new functions and the user object along with .save() to manipulate database data