### PR TITLE
feat: create lotteryWins and scratchJackpots stats

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -129,6 +129,7 @@ class Falbot {
 
 				const winnerFile = await this.database.player.findOne(winner.id);
 				winnerFile.falcoins += lotto.prize;
+				winnerFile.stats.set('lotteryWins', (winnerFile.stats.get('lotteryWins') ?? 0) + lotto.prize);
 				winnerFile.save();
 
 				var winnerUser = await this.client.users.fetch(winner.id);

--- a/src/commands/economy/scratch.js
+++ b/src/commands/economy/scratch.js
@@ -65,6 +65,7 @@ module.exports = {
 					//jackpot
 					amount = randint(200000, 300000);
 					player.falcoins += amount;
+					player.stats.set('scratchJackpots', (player.stats.get('scratchJackpots') ?? 0) + 1);
 					embed.setColor(15844367).addFields({
 						name: instance.getMessage(interaction, 'SCRATCH_PRIZE'),
 						value: `${instance.getMessage(interaction, 'SCRATCH_PRIZE_DESCRIPTION', {

--- a/src/commands/economy/stats.js
+++ b/src/commands/economy/stats.js
@@ -88,6 +88,19 @@ module.exports = {
 						name: `:hammer_pick: ${instance.getMessage(interaction, 'STATS_CRAFTS')}`,
 						value: `${format(player.stats.get('itemsCrafted'))} ${instance.getMessage(interaction, 'STATS_ITEMS')}`,
 						inline: true,
+					},
+					{
+						name: `:tickets: ${instance.getMessage(interaction, 'STATS_LOTTERY')}`,
+						value: `${format(player.stats.get('lotteryWins') ?? 0)} falcoins`,
+						inline: true,
+					},
+					{
+						name: `:confetti_ball: ${instance.getMessage(interaction, 'STATS_SCRATCH')}`,
+						value: `${format(player.stats.get('scratchJackpots') ?? 0)} ${instance.getMessage(
+							interaction,
+							'STATS_TIMES'
+						)}`,
+						inline: true,
 					}
 				);
 

--- a/src/schemas/user-schema.js
+++ b/src/schemas/user-schema.js
@@ -76,6 +76,8 @@ const userSchema = mongoose.Schema(
 				['timesMined', 0],
 				['timesVoted', 0],
 				['itemsCrafted', 0],
+				['lotteryWins', 0],
+				['scratchJackpots', 0],
 			]),
 		},
 	},

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1551,6 +1551,16 @@
 		"en-US": "Items crafted",
 		"es-ES": "Artículos construidos"
 	},
+	"STATS_LOTTERY": {
+		"pt-BR": "Lucros na Loteria",
+		"en-US": "Lottery Profits",
+		"es-ES": "Ganancias de Lotería"
+	},
+	"STATS_SCRATCH": {
+		"pt-BR": "Jackpots Raspadinha",
+		"en-US": "Scratch-off Jackpots",
+		"es-ES": "Jackpots Raspadinha"
+	},
 	"OVERTIME": {
 		"pt-BR": "**:crescent_moon: Horas extras - 3x** bônus de trabalho ({TIME})",
 		"en-US": "**:crescent_moon: Overtime - 3x** work bonus ({TIME})",


### PR DESCRIPTION
## What does this PR do?
Creates two new statistics, one that tracks earnings from lottery and one that tracks jackpots from scratch

## Media
![image](https://github.com/falcao-g/Falbot/assets/60127788/cdfcde58-097d-40e5-8c1c-bab46491d72b)
