### PR TITLE
fix: leaderboard item description missing emoji

### DIFF
--- a/src/commands/economy/leaderboard.js
+++ b/src/commands/economy/leaderboard.js
@@ -277,7 +277,7 @@ module.exports = {
 					);
 					embeds[i].setDescription(
 						`${instance.getMessage(interaction, `LEADERBOARD_${subcommand.toUpperCase()}_DESCRIPTION`, {
-							ITEM: subcommand == 'item' ? itemJSON[interaction.locale] ?? itemJSON['en-US'] : '',
+							ITEM: subcommand == 'item' ? instance.getItemName(item, interaction) : '',
 						})}`
 					);
 				}


### PR DESCRIPTION
fixes #97 

## What does this PR do?
Fixes the bug where the item emoji was missing from the leaderboard description

## Summary of changes
- Used the new getItemName function in embed description when is a item leaderboard