### PR TITLE
feat: improve commands luck when events are active

### DIFF
--- a/src/commands/economy/explore.js
+++ b/src/commands/economy/explore.js
@@ -23,6 +23,7 @@ module.exports = {
 		const inventoryWorth = instance.getInventoryWorth(player.inventory);
 		var buff = 1;
 		var buffText = '';
+		var luck = 1;
 
 		if (inventoryWorth >= limit) {
 			instance.editReply(interaction, {
@@ -53,6 +54,7 @@ module.exports = {
 			if (buffText !== '') buffText += '\n';
 			buffText += `${instance.getMessage(interaction, 'SEARCH_PARTY_BONUS')}`;
 			buff ? (buff *= 2) : (buff = 2);
+			luck = 1.5;
 		}
 
 		// define the weight of each rarity level (the sum of all weights should be 1)
@@ -86,8 +88,9 @@ module.exports = {
 		var total = 0;
 		var text = '';
 		for (let i = 0; i < numItems; i++) {
-			var selectedItem = pick(filteredItems);
-			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * randint(1, buff);
+			var selectedItem = pick(filteredItems, luck);
+			var softenedBuff = randint((buff * 10) / 2, buff * 10) / 10;
+			var amount = Math.floor(randint(1, amounts[items[selectedItem]['rarity']]) * softenedBuff);
 			var name = `${instance.getItemName(selectedItem, interaction)}`;
 			total += amount;
 			text += `**${name}** x ${amount}\n`;

--- a/src/commands/economy/fish.js
+++ b/src/commands/economy/fish.js
@@ -23,6 +23,7 @@ module.exports = {
 		const inventoryWorth = instance.getInventoryWorth(player.inventory);
 		var buff = 1;
 		var buffText = '';
+		var luck = 1;
 
 		if (inventoryWorth >= limit) {
 			instance.editReply(interaction, {
@@ -53,6 +54,7 @@ module.exports = {
 			if (buffText !== '') buffText += '\n';
 			buffText += `${instance.getMessage(interaction, 'FLOOD_BONUS')}`;
 			buff ? (buff *= 2) : (buff = 2);
+			luck = 1.5;
 		}
 
 		// define the weight of each rarity level (the sum of all weights should be 1)
@@ -86,8 +88,9 @@ module.exports = {
 		var total = 0;
 		var text = '';
 		for (let i = 0; i < numItems; i++) {
-			var selectedItem = pick(filteredItems);
-			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * randint(1, buff);
+			var selectedItem = pick(filteredItems, luck);
+			var softenedBuff = randint((buff * 10) / 2, buff * 10) / 10;
+			var amount = Math.floor(randint(1, amounts[items[selectedItem]['rarity']]) * softenedBuff);
 			var name = `${instance.getItemName(selectedItem, interaction)}`;
 			total += amount;
 			text += `**${name}** x ${amount}\n`;

--- a/src/commands/economy/hunt.js
+++ b/src/commands/economy/hunt.js
@@ -23,6 +23,7 @@ module.exports = {
 		const inventoryWorth = instance.getInventoryWorth(player.inventory);
 		var buff = 1;
 		var buffText = '';
+		var luck = 1;
 
 		if (inventoryWorth >= limit) {
 			instance.editReply(interaction, {
@@ -53,6 +54,7 @@ module.exports = {
 			if (buffText !== '') buffText += '\n';
 			buffText += `${instance.getMessage(interaction, 'STAMPEDE_BONUS')}`;
 			buff ? (buff *= 2) : (buff = 2);
+			luck = 1.5;
 		}
 
 		// define the weight of each rarity level (the sum of all weights should be 1)
@@ -86,8 +88,9 @@ module.exports = {
 		var total = 0;
 		var text = '';
 		for (let i = 0; i < numItems; i++) {
-			var selectedItem = pick(filteredItems);
-			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * randint(1, buff);
+			var selectedItem = pick(filteredItems, luck);
+			var softenedBuff = randint((buff * 10) / 2, buff * 10) / 10;
+			var amount = Math.floor(randint(1, amounts[items[selectedItem]['rarity']]) * softenedBuff);
 			var name = `${instance.getItemName(selectedItem, interaction)}`;
 			total += amount;
 			text += `**${name}** x ${amount}\n`;

--- a/src/commands/economy/mine.js
+++ b/src/commands/economy/mine.js
@@ -23,6 +23,7 @@ module.exports = {
 		const inventoryWorth = instance.getInventoryWorth(player.inventory);
 		var buff = 1;
 		var buffText = '';
+		var luck = 1;
 
 		if (inventoryWorth >= limit) {
 			instance.editReply(interaction, {
@@ -53,6 +54,7 @@ module.exports = {
 			if (buffText !== '') buffText += '\n';
 			buffText += `${instance.getMessage(interaction, 'COMET_BONUS')}`;
 			buff ? (buff *= 2) : (buff = 2);
+			luck = 1.5;
 		}
 
 		// define the weight of each rarity level (the sum of all weights should be 1)
@@ -86,8 +88,9 @@ module.exports = {
 		var total = 0;
 		var text = '';
 		for (let i = 0; i < numItems; i++) {
-			var selectedItem = pick(filteredItems);
-			var amount = randint(1, amounts[items[selectedItem]['rarity']]) * randint(1, buff);
+			var selectedItem = pick(filteredItems, luck);
+			var softenedBuff = randint((buff * 10) / 2, buff * 10) / 10;
+			var amount = Math.floor(randint(1, amounts[items[selectedItem]['rarity']]) * softenedBuff);
 			var name = `${instance.getItemName(selectedItem, interaction)}`;
 			total += amount;
 			text += `**${name}** x ${amount}\n`;

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -161,11 +161,11 @@ function paginate() {
 /**
  *
  * @param {Array<string, number>} data
- * @description Picks a random element from an array based on its weight
- * @example pick([['a', 0.5], ['b', 0.3], ['c', 0.2]]) // 'a'
+ * @description Picks a random element from an array based on its weight, you can also alter the luck
+ * @example pick([['a', 0.5], ['b', 0.3], ['c', 0.2]], 1) // 'a'
  * @returns {string}
  */
-function pick(data) {
+function pick(data, luck = 1) {
 	// Split input into two separate arrays of values and weights.
 	const values = data.map((d) => d[0]);
 	const weights = data.map((d) => d[1]);
@@ -176,9 +176,10 @@ function pick(data) {
 		acc = element + acc;
 		return acc;
 	});
-	const rand = Math.random() * sum;
-
-	return values[weightsSum.filter((element) => element <= rand).length];
+	const rand = Math.random() * sum * luck;
+	let index = weightsSum.filter((element) => element <= rand).length;
+	index = index >= weights.length ? weights.length - 1 : index;
+	return values[index];
 }
 
 /**


### PR DESCRIPTION
fixes #92 

## What does this PR do?
Improve gathering item commands luck when the random events are active

## Summary of changes
- Change pick function to have a luck argument that impacts the pick weight
- Make fish, hunt, explore and mine commands have improved luck when their respective random events are active
