### PR TITLE
Create a farming system

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -331,6 +331,13 @@ class Falbot {
 				});
 				perks += '\n';
 			}
+
+			if (old_rank.farmPlots < rank.farmPlots) {
+				perks += this.getMessage(interaction, 'RANKUP_FARM', {
+					PLOTS: format(rank.farmPlots - old_rank.farmPlots),
+				});
+				perks += '\n';
+			}
 		}
 
 		perks += `${this.getMessage(interaction, 'VOTE')}: ${format(rank.vote)} Falcoins\n`;

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -126,6 +126,11 @@ module.exports = {
 			.createEmbed(member.displayColor)
 			.setTitle(instance.getMessage(interaction, 'FARM_TITLE', { USER: member.displayName }));
 
+		/**
+		 * Renders buttons ignoring the specified type.
+		 * @param {string} type - The type of button to ignore.
+		 * @returns {ActionRowBuilder} - The ActionRowBuilder object containing the rendered buttons.
+		 */
 		function renderButtons(type) {
 			const availableButtons = [
 				new ButtonBuilder()
@@ -160,6 +165,12 @@ module.exports = {
 			return new ActionRowBuilder().addComponents(...filteredButtons);
 		}
 
+		/**
+		 * Renders the plots for the farm.
+		 * @param {Object} plotsWatered - An array of plots that have been watered.
+		 * @param {Object} newPlot - An array of new plots.
+		 * @returns {Array} - An array of plot objects with name, value, and inline properties.
+		 */
 		function renderPlots({ plotsWatered = [], newPlot = [] }) {
 			return player.plots.map((plot, index) => {
 				const timeLeft = plot.harvestTime - Date.now();
@@ -213,6 +224,7 @@ module.exports = {
 				cropName = args[1];
 			}
 
+			// If no crop name is provided, show a list of crops that can be planted.
 			if (!cropName) {
 				const cropsKeys = Object.keys(items).filter((key) => items[key].hasOwnProperty('growTime'));
 				const canPlant = cropsKeys.map((cropKey) => {
@@ -249,6 +261,7 @@ module.exports = {
 				const cropKey = getItem(cropName);
 				const cropJSON = items[cropKey];
 
+				// Add the plot to the player's plots array.
 				player.plots.push({
 					crop: cropKey,
 					harvestTime: Date.now() + cropJSON.growTime,
@@ -264,6 +277,7 @@ module.exports = {
 		} else if (type === 'water') {
 			const plotsWatered = [];
 
+			// Loop through each plot and water all crops.
 			player.plots.forEach((plot, index) => {
 				if (plot.lastWatered + 60 * 60 * 1000 <= Date.now()) {
 					plot.harvestTime -= 45 * 60 * 1000;
@@ -271,7 +285,6 @@ module.exports = {
 					plotsWatered.push(index);
 				}
 			});
-
 			await player.save();
 
 			if (plotsWatered.length === 0) {
@@ -288,6 +301,7 @@ module.exports = {
 				const harvestedCrops = {};
 				let total = 0;
 
+				// Loop through each plot and harvest the crops that are ready.
 				player.plots.forEach(async (plot, index) => {
 					if (plot.harvestTime <= Date.now()) {
 						const cropKey = plot.crop;
@@ -324,6 +338,7 @@ module.exports = {
 				plotIndex = args[1];
 			}
 
+			// If no plot index is provided, show a list of plots that can be uprooted.
 			if (!plotIndex) {
 				const options = [];
 				for (let i = 0; i < player.plots.length; i++) {
@@ -358,6 +373,7 @@ module.exports = {
 			} else {
 				const cropKey = player.plots[plotIndex - 1].crop;
 
+				// Remove the plot from the player's plots array.
 				player.plots.splice(plotIndex - 1, 1);
 				await player.save();
 
@@ -370,10 +386,12 @@ module.exports = {
 			}
 		}
 
+		// Render embed and buttons.
 		interaction.editReply({ embeds: [embed], components: [renderButtons(type)] });
 	},
 	autocomplete: async ({ interaction, instance }) => {
 		const focusedValue = interaction.options.getFocused().toLowerCase();
+
 		const cropsKeys = Object.keys(instance.items).filter((key) => instance.items[key].hasOwnProperty('growTime'));
 		const localeCrops = cropsKeys.map((key) => instance.getItemName(key, interaction));
 		const filtered = localeCrops.filter((choice) => {
@@ -383,6 +401,7 @@ module.exports = {
 				lowerCaseChoice.split(' ').slice(1).join(' ').startsWith(focusedValue)
 			);
 		});
+
 		await interaction.respond(filtered.slice(0, 25).map((choice) => ({ name: choice, value: choice })));
 	},
 };

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -374,7 +374,7 @@ module.exports = {
 			}
 
 			if (player.plots.length === 0) {
-				embed.setDescription(instance.getMessage(interaction, 'NO_PLOTS_TO_UPROOT'));
+				embed.setDescription(instance.getMessage(interaction, 'NO_CROPS_TO_UPROOT'));
 			} else if (plotIndex > player.plots.length || plotIndex <= 0) {
 				embed.setDescription(instance.getMessage(interaction, 'INVALID_PLOT'));
 			} else {

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -259,7 +259,7 @@ module.exports = {
 			const cropKey = getItem(cropName);
 			const cropJSON = items[cropKey];
 
-			if (cropJSON && !cropJSON.hasOwnProperty('growTime')) {
+			if (cropJSON === undefined || !cropJSON.hasOwnProperty('growTime')) {
 				embed.setDescription(instance.getMessage(interaction, 'INVALID_CROP'));
 			} else if (player.plots.length >= MAX_PLOTS) {
 				embed.setDescription(instance.getMessage(interaction, 'NO_PLOTS_AVAILABLE'));

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -168,8 +168,7 @@ module.exports = {
 
 		/**
 		 * Renders the plots for the farm.
-		 * @param {Object} plotsWatered - An array of plots that have been watered.
-		 * @param {Object} newPlot - An array of new plots.
+		 * @param {Array} newPlot - An array of new plots.
 		 * @returns {Array} - An array of plot objects with name, value, and inline properties.
 		 */
 		function renderPlots({ newPlot = [] }) {

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -255,14 +255,14 @@ module.exports = {
 				return;
 			}
 
-			if (!items[cropName].hasOwnProperty('growTime')) {
+			const cropKey = getItem(cropName);
+			const cropJSON = items[cropKey];
+
+			if (cropJSON && !cropJSON.hasOwnProperty('growTime')) {
 				embed.setDescription(instance.getMessage(interaction, 'INVALID_CROP'));
 			} else if (player.plots.length >= MAX_PLOTS) {
 				embed.setDescription(instance.getMessage(interaction, 'NO_PLOTS_AVAILABLE'));
 			} else {
-				const cropKey = getItem(cropName);
-				const cropJSON = items[cropKey];
-
 				// Add the plot to the player's plots array.
 				player.plots.push({
 					crop: cropKey,

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -117,11 +117,16 @@ module.exports = {
 			var type = subcommand;
 		}
 
-		const MAX_PLOTS = 6;
 		const WATER_COOLDOWN = 60 * 60 * 1000;
 
-		const player = await User.findByIdAndUpdate(member.id, {}, { select: 'plots inventory', upsert: true, new: true });
+		const player = await User.findByIdAndUpdate(
+			member.id,
+			{},
+			{ select: 'plots inventory rank', upsert: true, new: true }
+		);
 		const items = instance.items;
+
+		const MAX_PLOTS = instance.levels[player.rank - 1].farmPlots;
 
 		const embed = instance
 			.createEmbed(member.displayColor)

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -302,19 +302,19 @@ module.exports = {
 				let total = 0;
 
 				// Loop through each plot and harvest the crops that are ready.
-				player.plots.forEach(async (plot, index) => {
-					if (plot.harvestTime <= Date.now()) {
-						const cropKey = plot.crop;
+				for (let i = player.plots.length - 1; i >= 0; i--) {
+					if (player.plots[i].harvestTime <= Date.now()) {
+						const cropKey = player.plots[i].crop;
 						const cropJSON = items[cropKey];
 
 						const amount = randint(cropJSON.harvestAmount.min, cropJSON.harvestAmount.max);
 						total += amount;
 
 						await player.inventory.set(cropKey, (player.inventory.get(cropKey) || 0) + amount);
-						await plot.remove();
+						await player.plots.splice(i, 1);
 						harvestedCrops[cropKey] = (harvestedCrops[cropKey] || 0) + amount;
 					}
-				});
+				}
 				await player.save();
 
 				if (total === 0) {

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -255,7 +255,9 @@ module.exports = {
 				return;
 			}
 
-			if (player.plots.length >= MAX_PLOTS) {
+			if (!items[cropName].hasOwnProperty('growTime')) {
+				embed.setDescription(instance.getMessage(interaction, 'INVALID_CROP'));
+			} else if (player.plots.length >= MAX_PLOTS) {
 				embed.setDescription(instance.getMessage(interaction, 'NO_PLOTS_AVAILABLE'));
 			} else {
 				const cropKey = getItem(cropName);

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -49,6 +49,7 @@ module.exports = {
 							'es-ES': 'Cultivo para plantar',
 						})
 						.setRequired(true)
+						.setAutocomplete(true)
 				)
 		)
 		.addSubcommand((subcommand) =>
@@ -290,7 +291,19 @@ module.exports = {
 			interaction.editReply({ embeds: [embed], components: [row] });
 		}
 	},
+	autocomplete: async ({ interaction, instance }) => {
+		const focusedValue = interaction.options.getFocused().toLowerCase();
+		const cropsKeys = Object.keys(instance.items).filter((key) => instance.items[key].hasOwnProperty('growTime'));
+		const localeCrops = cropsKeys.map((key) => instance.getItemName(key, interaction));
+		const filtered = localeCrops.filter((choice) => {
+			const lowerCaseChoice = choice.toLowerCase();
+			return (
+				lowerCaseChoice.startsWith(focusedValue) ||
+				lowerCaseChoice.split(' ').slice(1).join(' ').startsWith(focusedValue)
+			);
+		});
+		await interaction.respond(filtered.slice(0, 25).map((choice) => ({ name: choice, value: choice })));
+	},
 };
 
-// TODO: Add autocomplete
 // TODO: Add more buttons

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } = require('discord.js');
-const { msToTime, getItem } = require('../../utils/functions.js');
+const { msToTime, getItem, randint } = require('../../utils/functions.js');
 const User = require('../../schemas/user-schema.js');
 
 module.exports = {
@@ -204,6 +204,8 @@ module.exports = {
 
 			interaction.editReply({ embeds: [embed], components: [row] });
 		} else if (type === 'water') {
+			const row = new ActionRowBuilder().addComponents(viewButton, plantButton, harvestButton, uprootButton);
+
 			const plotsWatered = [];
 
 			player.plots.forEach((plot, index) => {
@@ -224,7 +226,7 @@ module.exports = {
 					.addFields(...renderPlots({ plotsWatered }));
 			}
 
-			interaction.editReply({ embeds: [embed] });
+			interaction.editReply({ embeds: [embed], components: [row] });
 		} else if (type === 'harvest') {
 			const row = new ActionRowBuilder().addComponents(viewButton, plantButton, uprootButton);
 
@@ -237,8 +239,9 @@ module.exports = {
 				player.plots.forEach(async (plot, index) => {
 					if (plot.harvestTime <= Date.now()) {
 						const cropKey = plot.crop;
+						const cropJSON = instance.items[cropKey];
 
-						const amount = 6;
+						const amount = randint(cropJSON.harvestAmount.min, cropJSON.harvestAmount.max);
 						total += amount;
 
 						await player.inventory.set(cropKey, (player.inventory.get(cropKey) || 0) + amount);

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -238,8 +238,6 @@ module.exports = {
 			});
 			await player.save();
 
-			console.log(harvestedCrops);
-
 			if (total === 0) {
 				embed.setDescription('No crops were harvested!');
 			} else {

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -187,7 +187,7 @@ module.exports = {
 				return {
 					name: `${instance.getMessage(interaction, 'PLOT')} ${index + 1} ${
 						plot.lastWatered + WATER_COOLDOWN > Date.now() ? '💧' : ''
-					} ${newPlot.includes(index) ? '❇️' : ''}`,
+					} *(${msToTime(plot.lastWatered + WATER_COOLDOWN - Date.now())})* ${newPlot.includes(index) ? '❇️' : ''}`,
 					value: `${crop.repeat(6)}\n${
 						timeLeft > 0
 							? instance.getMessage(interaction, 'REMAINING_TIME', {

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -1,0 +1,287 @@
+const { SlashCommandBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } = require('discord.js');
+const { msToTime, getItem } = require('../../utils/functions.js');
+const User = require('../../schemas/user-schema.js');
+
+module.exports = {
+	data: new SlashCommandBuilder()
+		.setName('farm')
+		.setNameLocalizations({
+			'pt-BR': 'fazenda',
+			'es-ES': 'granja',
+		})
+		.setDescription('Farm commands')
+		.setDMPermission(false)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('view')
+				.setNameLocalizations({
+					'pt-BR': 'ver',
+					'es-ES': 'ver',
+				})
+				.setDescription('View your farm')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Veja sua fazenda',
+					'es-ES': 'Ve tu granja',
+				})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('plant')
+				.setNameLocalizations({
+					'pt-BR': 'plantar',
+					'es-ES': 'plantar',
+				})
+				.setDescription('Plant a crop')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Plante uma safra',
+					'es-ES': 'Planta un cultivo',
+				})
+				.addStringOption((option) =>
+					option
+						.setName('crop')
+						.setNameLocalizations({
+							'pt-BR': 'cultura',
+							'es-ES': 'cultivo',
+						})
+						.setDescription('Crop to plant')
+						.setDescriptionLocalizations({
+							'pt-BR': 'Cultura para plantar',
+							'es-ES': 'Cultivo para plantar',
+						})
+						.setRequired(true)
+				)
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('water')
+				.setNameLocalizations({
+					'pt-BR': 'regar',
+					'es-ES': 'regar',
+				})
+				.setDescription('Water a crop')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Regue uma safra',
+					'es-ES': 'Riega un cultivo',
+				})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('harvest')
+				.setNameLocalizations({
+					'pt-BR': 'colher',
+					'es-ES': 'cosechar',
+				})
+				.setDescription('Harvest a crop')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Colha uma safra',
+					'es-ES': 'Cosecha un cultivo',
+				})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('uproot')
+				.setNameLocalizations({
+					'pt-BR': 'arrancar',
+					'es-ES': 'arrancar',
+				})
+				.setDescription('Uproot a crop')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Arranque uma safra',
+					'es-ES': 'Arranca un cultivo',
+				})
+				.addIntegerOption((option) =>
+					option
+						.setName('plot')
+						.setNameLocalizations({
+							'pt-BR': 'safra',
+							'es-ES': 'cultivo',
+						})
+						.setDescription('Plot to uproot')
+						.setDescriptionLocalizations({
+							'pt-BR': 'Safra para arrancar',
+							'es-ES': 'Cultivo para arrancar',
+						})
+						.setRequired(true)
+				)
+		),
+	execute: async ({ interaction, instance, subcommand, member }) => {
+		await interaction.deferReply().catch(() => {});
+		try {
+			var type = interaction.options.getSubcommand();
+		} catch {
+			var type = subcommand;
+		}
+
+		const player = await User.findByIdAndUpdate(member.id, {}, { select: 'plots inventory', upsert: true, new: true });
+
+		const viewButton = new ButtonBuilder().setCustomId('farm view').setLabel('🏡').setStyle(ButtonStyle.Primary);
+
+		const plantButton = new ButtonBuilder()
+			.setCustomId('farm plant')
+			.setLabel('🌱')
+			.setStyle(ButtonStyle.Primary)
+			.setDisabled(true);
+
+		const harvestButton = new ButtonBuilder().setCustomId('farm harvest').setLabel('🚜').setStyle(ButtonStyle.Success);
+
+		const uprootButton = new ButtonBuilder()
+			.setCustomId('farm uproot')
+			.setLabel('🔨')
+			.setStyle(ButtonStyle.Danger)
+			.setDisabled(true);
+
+		if (type === 'view') {
+			const plots = player.plots.map((plot, index) => {
+				const timeLeft = plot.harvestTime - Date.now();
+
+				const cropEmoji = instance.items[plot.crop].emoji;
+
+				const crop = timeLeft > 0 ? '🌱' : cropEmoji;
+
+				return {
+					name: `Plot ${index + 1}`,
+					value: `${crop.repeat(6)}\n${
+						timeLeft > 0 ? `${cropEmoji} in ${msToTime(timeLeft)}` : '**Ready to harvest!**'
+					}`,
+					inline: true,
+				};
+			});
+
+			const embed = instance
+				.createEmbed()
+				.setTitle(`🏞️ ${member.displayName}'s Farm`)
+				.setColor(member.displayColor)
+				.setDescription('💦 **Water crops to lower grow time!**')
+				.addFields(plots.length > 0 ? [...plots] : { name: 'No plots', value: 'Use `/farm plant` to plant a crop!' });
+
+			const row = new ActionRowBuilder().addComponents(plantButton, harvestButton, uprootButton);
+
+			interaction.editReply({ embeds: [embed], components: [row] });
+		} else if (type === 'plant') {
+			const cropName = interaction.options.getString('crop');
+
+			if (player.plots.length >= 6) {
+				const embed = instance.createEmbed(member.displayColor).setTitle(`🏞️ ${member.displayName}'s Farm`);
+				embed.setDescription('You have no more plots!');
+
+				return interaction.editReply({ embeds: [embed] });
+			}
+
+			const cropKey = getItem(cropName);
+			const cropJSON = instance.items[cropKey];
+
+			player.plots.push({
+				crop: cropKey,
+				harvestTime: Date.now() + cropJSON.growTime,
+			});
+			await player.save();
+
+			const embed = instance
+				.createEmbed(member.displayColor)
+				.setTitle(`🏞️ ${member.displayName}'s Farm`)
+				.setDescription(`Planted **${instance.getItemName(cropKey, interaction)}**!`);
+			const row = new ActionRowBuilder().addComponents(viewButton, harvestButton, uprootButton);
+
+			interaction.editReply({ embeds: [embed], components: [row] });
+		} else if (type === 'water') {
+			const embed = instance.createEmbed(member.displayColor).setTitle(`🏞️ ${member.displayName}'s Farm`);
+
+			if (player.plots.length === 0) {
+				embed.setDescription('You have no crops to water!');
+
+				return interaction.editReply({ embeds: [embed] });
+			}
+
+			let total = 0;
+
+			player.plots.forEach((plot) => {
+				if (plot.lastWatered + 60 * 60 * 1000 <= Date.now()) {
+					plot.harvestTime -= 45 * 60 * 1000;
+					plot.lastWatered = Date.now();
+					total++;
+				}
+			});
+
+			await player.save();
+
+			if (total === 0) {
+				embed.setDescription('No plots were watered!');
+			} else {
+				embed.setDescription(`Watered ${total} plots!`);
+			}
+
+			interaction.editReply({ embeds: [embed] });
+		} else if (type === 'harvest') {
+			const embed = instance.createEmbed(member.displayColor).setTitle(`🏞️ ${member.displayName}'s Farm`);
+			const row = new ActionRowBuilder().addComponents(viewButton, plantButton, uprootButton);
+
+			if (player.plots.length === 0) {
+				embed.setDescription('You have no crops to harvest!');
+
+				return interaction.editReply({ embeds: [embed], components: [row] });
+			}
+
+			const harvestedCrops = {};
+			let total = 0;
+
+			player.plots.forEach((plot, index) => {
+				if (plot.harvestTime <= Date.now()) {
+					const cropKey = plot.crop;
+
+					const amount = 6;
+					total += amount;
+
+					player.inventory.set(cropKey, (player.inventory.get(cropKey) || 0) + amount);
+					player.plots.splice(index, 1);
+					harvestedCrops[cropKey] = (harvestedCrops[cropKey] || 0) + amount;
+				}
+			});
+			await player.save();
+
+			console.log(harvestedCrops);
+
+			if (total === 0) {
+				embed.setDescription('No crops were harvested!');
+			} else {
+				embed.addFields({
+					name: `🚜 ${total} crops harvested!`,
+					value: Object.keys(harvestedCrops)
+						.map((cropKey) => `**${instance.getItemName(cropKey, interaction)}** x ${harvestedCrops[cropKey]}`)
+						.join('\n'),
+				});
+			}
+
+			interaction.editReply({ embeds: [embed], components: [row] });
+		} else if (type === 'uproot') {
+			const plot = interaction.options.getInteger('plot');
+
+			const embed = instance.createEmbed(member.displayColor).setTitle(`🏞️ ${member.displayName}'s Farm`);
+			const row = new ActionRowBuilder().addComponents(viewButton, plantButton, harvestButton);
+
+			if (player.plots.length === 0) {
+				embed.setDescription('You have no crops to uproot!');
+
+				return interaction.editReply({ embeds: [embed], components: [row] });
+			}
+
+			if (plot > player.plots.length || plot <= 0) {
+				embed.setDescription('Invalid plot!');
+
+				return interaction.editReply({ embeds: [embed], components: [row] });
+			}
+
+			const cropKey = player.plots[plot - 1].crop;
+
+			player.plots.splice(plot - 1, 1);
+			await player.save();
+
+			embed.setDescription(`Uprooted **${instance.getItemName(cropKey, interaction)}**! from plot ${plot}`);
+
+			interaction.editReply({ embeds: [embed], components: [row] });
+		}
+	},
+};
+
+// TODO: Add translations
+// TODO: Add more crops
+// TODO: Add more buttons

--- a/src/commands/economy/farm.js
+++ b/src/commands/economy/farm.js
@@ -29,6 +29,20 @@ module.exports = {
 					'pt-BR': 'Veja sua fazenda',
 					'es-ES': 'Ve tu granja',
 				})
+				.addUserOption((option) =>
+					option
+						.setName('user')
+						.setNameLocalizations({
+							'pt-BR': 'usuário',
+							'es-ES': 'usuario',
+						})
+						.setDescription('The user you want to view the farm of')
+						.setDescriptionLocalizations({
+							'pt-BR': 'O usuário que você deseja ver a fazenda',
+							'es-ES': 'El usuario que quieres ver la granja',
+						})
+						.setRequired(false)
+				)
 		)
 		.addSubcommand((subcommand) =>
 			subcommand
@@ -109,7 +123,7 @@ module.exports = {
 						})
 				)
 		),
-	execute: async ({ interaction, instance, subcommand, member, args }) => {
+	execute: async ({ interaction, instance, subcommand, member, args, guild }) => {
 		await interaction.deferReply().catch(() => {});
 		try {
 			var type = interaction.options.getSubcommand();
@@ -119,8 +133,10 @@ module.exports = {
 
 		const WATER_COOLDOWN = 60 * 60 * 1000;
 
+		const user = interaction.options && interaction.options.getUser('user', false);
+		const target = user ? await guild.members.fetch(user.id) : member;
 		const player = await User.findByIdAndUpdate(
-			member.id,
+			target.id,
 			{},
 			{ select: 'plots inventory rank', upsert: true, new: true }
 		);
@@ -129,8 +145,8 @@ module.exports = {
 		const MAX_PLOTS = instance.levels[player.rank - 1].farmPlots;
 
 		const embed = instance
-			.createEmbed(member.displayColor)
-			.setTitle(instance.getMessage(interaction, 'FARM_TITLE', { USER: member.displayName }));
+			.createEmbed(target.displayColor)
+			.setTitle(instance.getMessage(interaction, 'FARM_TITLE', { USER: target.displayName }));
 
 		/**
 		 * Renders buttons ignoring the specified type.

--- a/src/commands/economy/item.js
+++ b/src/commands/economy/item.js
@@ -84,6 +84,10 @@ module.exports = {
 				information += `\n${instance.getMessage(interaction, 'MYTHICAL')}`;
 			}
 
+			if (itemJSON.growTime != undefined) {
+				information += `\n${instance.getMessage(interaction, 'PLANTABLE')}`;
+			}
+
 			if (itemJSON.equip != undefined) {
 				information += `\n${instance.getMessage(interaction, 'EQUIPPABLE')}`;
 				information += `\n${instance.getMessage(interaction, itemJSON.effect.toUpperCase())}`;

--- a/src/commands/utility/help.js
+++ b/src/commands/utility/help.js
@@ -62,6 +62,16 @@ module.exports = {
 						name: '⚙️ config',
 						name_localizations: { 'pt-BR': '⚙️ configuração', 'es-ES': '⚙️ configuración' },
 						value: 'config',
+					},
+					{
+						name: '🏪 market',
+						name_localizations: { 'pt-BR': '🏪 mercado', 'es-ES': '🏪 mercado' },
+						value: 'market',
+					},
+					{
+						name: '🏞️ farm',
+						name_localizations: { 'pt-BR': '🏞️ fazenda', 'es-ES': '🏞️ granja' },
+						value: 'farm',
 					}
 				)
 		),
@@ -117,6 +127,16 @@ module.exports = {
 					name: instance.getMessage(interaction, 'HELP_CONFIG'),
 					value: instance.getMessage(interaction, 'HELP_CONFIG2'),
 				});
+			} else if (page === 'market') {
+				embed.addFields({
+					name: instance.getMessage(interaction, 'HELP_MARKET'),
+					value: instance.getMessage(interaction, 'HELP_MARKET2'),
+				});
+			} else if (page === 'farm') {
+				embed.addFields({
+					name: instance.getMessage(interaction, 'HELP_FARM'),
+					value: instance.getMessage(interaction, 'HELP_FARM2'),
+				});
 			} else {
 				embed.setTitle(instance.getMessage(interaction, 'FALBOT_WELCOME'));
 				embed.addFields(
@@ -158,6 +178,16 @@ module.exports = {
 					{
 						name: ':gear: ' + instance.getMessage(interaction, 'CONFIG'),
 						value: instance.getMessage(interaction, 'HELP_CONFIG3'),
+						inline: true,
+					},
+					{
+						name: ':convenience_store: ' + instance.getMessage(interaction, 'MARKET'),
+						value: instance.getMessage(interaction, 'HELP_MARKET3'),
+						inline: true,
+					},
+					{
+						name: ':park: ' + instance.getMessage(interaction, 'FARM'),
+						value: instance.getMessage(interaction, 'HELP_FARM3'),
 						inline: true,
 					}
 				);
@@ -206,6 +236,16 @@ module.exports = {
 							label: instance.getMessage(interaction, 'CONFIG'),
 							value: 'config',
 							emoji: '⚙️',
+						},
+						{
+							label: instance.getMessage(interaction, 'MARKET'),
+							value: 'market',
+							emoji: '🏪',
+						},
+						{
+							label: instance.getMessage(interaction, 'FARM'),
+							value: 'farm',
+							emoji: '🏞️',
 						}
 					)
 			);

--- a/src/schemas/user-schema.js
+++ b/src/schemas/user-schema.js
@@ -80,6 +80,25 @@ const userSchema = mongoose.Schema(
 				['scratchJackpots', 0],
 			]),
 		},
+		plots: [
+			{
+				crop: {
+					type: String,
+					required: true,
+				},
+				harvestTime: {
+					type: Number,
+					default: 0,
+					required: true,
+				},
+				lastWatered: {
+					type: Number,
+					default: 0,
+					required: true,
+				},
+				_id: false,
+			},
+		],
 	},
 	{
 		versionKey: false,

--- a/src/schemas/user-schema.js
+++ b/src/schemas/user-schema.js
@@ -84,6 +84,7 @@ const userSchema = mongoose.Schema(
 			{
 				crop: {
 					type: String,
+					default: '',
 					required: true,
 				},
 				harvestTime: {
@@ -96,7 +97,6 @@ const userSchema = mongoose.Schema(
 					default: 0,
 					required: true,
 				},
-				_id: false,
 			},
 		],
 	},

--- a/src/schemas/user-schema.js
+++ b/src/schemas/user-schema.js
@@ -82,6 +82,7 @@ const userSchema = mongoose.Schema(
 		},
 		plots: [
 			{
+				_id: false,
 				crop: {
 					type: String,
 					default: '',

--- a/src/utils/json/items.json
+++ b/src/utils/json/items.json
@@ -206,7 +206,12 @@
 		"value": 50,
 		"rarity": "Common",
 		"emoji": "🌿",
-		"exploring": true
+		"exploring": true,
+		"growTime": 1800000,
+		"harvestAmount": {
+			"min": 30,
+			"max": 75
+		}
 	},
 	"rock": {
 		"en-US": "Rock",
@@ -975,19 +980,6 @@
 		"harvestAmount": {
 			"min": 5,
 			"max": 10
-		}
-	},
-	"herb": {
-		"en-US": "Herb",
-		"pt-BR": "Erva",
-		"es-ES": "Hierba",
-		"value": 0,
-		"rarity": "Uncommon",
-		"emoji": "🌾",
-		"growTime": 1800000,
-		"harvestAmount": {
-			"min": 30,
-			"max": 75
 		}
 	},
 	"potato": {

--- a/src/utils/json/items.json
+++ b/src/utils/json/items.json
@@ -207,7 +207,7 @@
 		"rarity": "Common",
 		"emoji": "🌿",
 		"exploring": true,
-		"growTime": 1800000,
+		"growTime": 5400000,
 		"harvestAmount": {
 			"min": 30,
 			"max": 75
@@ -895,10 +895,10 @@
 		"en-US": "Blueberry",
 		"pt-BR": "Mirtilo",
 		"es-ES": "Arándano",
-		"value": 0,
-		"rarity": "Uncommon",
+		"value": 75,
+		"rarity": "Common",
 		"emoji": "🫐",
-		"growTime": 300000,
+		"growTime": 3000000,
 		"harvestAmount": {
 			"min": 5,
 			"max": 10
@@ -908,10 +908,10 @@
 		"en-US": "Strawberry",
 		"pt-BR": "Morango",
 		"es-ES": "Fresa",
-		"value": 0,
-		"rarity": "Uncommon",
+		"value": 135,
+		"rarity": "Common",
 		"emoji": "🍓",
-		"growTime": 600000,
+		"growTime": 3600000,
 		"harvestAmount": {
 			"min": 5,
 			"max": 10
@@ -921,10 +921,10 @@
 		"en-US": "Kiwi",
 		"pt-BR": "Kiwi",
 		"es-ES": "Kiwi",
-		"value": 0,
+		"value": 375,
 		"rarity": "Uncommon",
 		"emoji": "🥝",
-		"growTime": 1800000,
+		"growTime": 5400000,
 		"harvestAmount": {
 			"min": 5,
 			"max": 10
@@ -934,10 +934,10 @@
 		"en-US": "Mango",
 		"pt-BR": "Manga",
 		"es-ES": "Mango",
-		"value": 0,
+		"value": 800,
 		"rarity": "Uncommon",
 		"emoji": "🥭",
-		"growTime": 3600000,
+		"growTime": 7200000,
 		"harvestAmount": {
 			"min": 5,
 			"max": 10
@@ -947,7 +947,7 @@
 		"en-US": "Melon",
 		"pt-BR": "Melão",
 		"es-ES": "Melón",
-		"value": 0,
+		"value": 3000,
 		"rarity": "Uncommon",
 		"emoji": "🍈",
 		"growTime": 14400000,
@@ -960,8 +960,8 @@
 		"en-US": "Coconut",
 		"pt-BR": "Coco",
 		"es-ES": "Coco",
-		"value": 0,
-		"rarity": "Uncommon",
+		"value": 6000,
+		"rarity": "Epic",
 		"emoji": "🥥",
 		"growTime": 28800000,
 		"harvestAmount": {
@@ -973,8 +973,8 @@
 		"en-US": "Pumpkin",
 		"pt-BR": "Abóbora",
 		"es-ES": "Calabaza",
-		"value": 0,
-		"rarity": "Uncommon",
+		"value": 17000,
+		"rarity": "Epic",
 		"emoji": "🎃",
 		"growTime": 86400000,
 		"harvestAmount": {
@@ -986,7 +986,7 @@
 		"en-US": "Potato",
 		"pt-BR": "Batata",
 		"es-ES": "Patata",
-		"value": 0,
+		"value": 1000,
 		"rarity": "Uncommon",
 		"emoji": "🥔",
 		"growTime": 259200000,

--- a/src/utils/json/items.json
+++ b/src/utils/json/items.json
@@ -839,7 +839,8 @@
 		"value": 400,
 		"rarity": "Epic",
 		"emoji": "🍀",
-		"exploring": true
+		"exploring": true,
+		"growTime": 345600000
 	},
 	"snowflake": {
 		"en-US": "Eternal Snowflake",

--- a/src/utils/json/items.json
+++ b/src/utils/json/items.json
@@ -840,7 +840,11 @@
 		"rarity": "Epic",
 		"emoji": "🍀",
 		"exploring": true,
-		"growTime": 345600000
+		"growTime": 21600000,
+		"harvestAmount": {
+			"min": 10,
+			"max": 100
+		}
 	},
 	"snowflake": {
 		"en-US": "Eternal Snowflake",
@@ -862,7 +866,13 @@
 		"es-ES": "Grano de Café",
 		"value": 150,
 		"rarity": "Uncommon",
-		"exploring": true
+		"emoji": "🫘",
+		"exploring": true,
+		"growTime": 10800000,
+		"harvestAmount": {
+			"min": 50,
+			"max": 100
+		}
 	},
 	"coffee": {
 		"pt-BR": "Café",
@@ -874,6 +884,123 @@
 		"effect": "work-2",
 		"recipe": {
 			"coffeebean": 40
+		}
+	},
+	"blueberry": {
+		"en-US": "Blueberry",
+		"pt-BR": "Mirtilo",
+		"es-ES": "Arándano",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🫐",
+		"growTime": 300000,
+		"harvestAmount": {
+			"min": 5,
+			"max": 10
+		}
+	},
+	"strawberry": {
+		"en-US": "Strawberry",
+		"pt-BR": "Morango",
+		"es-ES": "Fresa",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🍓",
+		"growTime": 600000,
+		"harvestAmount": {
+			"min": 5,
+			"max": 10
+		}
+	},
+	"kiwi": {
+		"en-US": "Kiwi",
+		"pt-BR": "Kiwi",
+		"es-ES": "Kiwi",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🥝",
+		"growTime": 1800000,
+		"harvestAmount": {
+			"min": 5,
+			"max": 10
+		}
+	},
+	"mango": {
+		"en-US": "Mango",
+		"pt-BR": "Manga",
+		"es-ES": "Mango",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🥭",
+		"growTime": 3600000,
+		"harvestAmount": {
+			"min": 5,
+			"max": 10
+		}
+	},
+	"melon": {
+		"en-US": "Melon",
+		"pt-BR": "Melão",
+		"es-ES": "Melón",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🍈",
+		"growTime": 14400000,
+		"harvestAmount": {
+			"min": 5,
+			"max": 10
+		}
+	},
+	"coconut": {
+		"en-US": "Coconut",
+		"pt-BR": "Coco",
+		"es-ES": "Coco",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🥥",
+		"growTime": 28800000,
+		"harvestAmount": {
+			"min": 5,
+			"max": 10
+		}
+	},
+	"pumpkin": {
+		"en-US": "Pumpkin",
+		"pt-BR": "Abóbora",
+		"es-ES": "Calabaza",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🎃",
+		"growTime": 86400000,
+		"harvestAmount": {
+			"min": 5,
+			"max": 10
+		}
+	},
+	"herb": {
+		"en-US": "Herb",
+		"pt-BR": "Erva",
+		"es-ES": "Hierba",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🌾",
+		"growTime": 1800000,
+		"harvestAmount": {
+			"min": 30,
+			"max": 75
+		}
+	},
+	"potato": {
+		"en-US": "Potato",
+		"pt-BR": "Batata",
+		"es-ES": "Patata",
+		"value": 0,
+		"rarity": "Uncommon",
+		"emoji": "🥔",
+		"growTime": 259200000,
+		"harvestAmount": {
+			"min": 250,
+			"max": 500
 		}
 	}
 }

--- a/src/utils/json/levels.json
+++ b/src/utils/json/levels.json
@@ -4,173 +4,198 @@
 		"vote": 10000,
 		"work": [1000, 1500],
 		"bankLimit": 100000,
-		"inventoryLimit": 500000
+		"inventoryLimit": 500000,
+		"farmPlots": 2
 	},
 	{
 		"falcoinsToLevelUp": 5000,
 		"vote": 10500,
 		"work": [1125, 1750],
 		"bankLimit": 100000,
-		"inventoryLimit": 500000
+		"inventoryLimit": 500000,
+		"farmPlots": 2
 	},
 	{
 		"falcoinsToLevelUp": 10000,
 		"vote": 11000,
 		"work": [1250, 2000],
 		"bankLimit": 100000,
-		"inventoryLimit": 1000000
+		"inventoryLimit": 1000000,
+		"farmPlots": 2
 	},
 	{
 		"falcoinsToLevelUp": 26000,
 		"vote": 11500,
 		"work": [1375, 2250],
 		"bankLimit": 150000,
-		"inventoryLimit": 1000000
+		"inventoryLimit": 1000000,
+		"farmPlots": 3
 	},
 	{
 		"falcoinsToLevelUp": 55000,
 		"vote": 12000,
 		"work": [1500, 2500],
 		"bankLimit": 150000,
-		"inventoryLimit": 1500000
+		"inventoryLimit": 1500000,
+		"farmPlots": 3
 	},
 	{
 		"falcoinsToLevelUp": 150000,
 		"vote": 12500,
 		"work": [1625, 2750],
 		"bankLimit": 150000,
-		"inventoryLimit": 1500000
+		"inventoryLimit": 1500000,
+		"farmPlots": 3
 	},
 	{
 		"falcoinsToLevelUp": 220000,
 		"vote": 13000,
 		"work": [1750, 3000],
 		"bankLimit": 200000,
-		"inventoryLimit": 2000000
+		"inventoryLimit": 2000000,
+		"farmPlots": 4
 	},
 	{
 		"falcoinsToLevelUp": 330000,
 		"vote": 13500,
 		"work": [1875, 3250],
 		"bankLimit": 200000,
-		"inventoryLimit": 2000000
+		"inventoryLimit": 2000000,
+		"farmPlots": 4
 	},
 	{
 		"falcoinsToLevelUp": 450000,
 		"vote": 14000,
 		"work": [2000, 3500],
 		"bankLimit": 200000,
-		"inventoryLimit": 2500000
+		"inventoryLimit": 2500000,
+		"farmPlots": 4
 	},
 	{
 		"falcoinsToLevelUp": 600000,
 		"vote": 14500,
 		"work": [2125, 3750],
 		"bankLimit": 250000,
-		"inventoryLimit": 2500000
+		"inventoryLimit": 2500000,
+		"farmPlots": 5
 	},
 	{
 		"falcoinsToLevelUp": 800000,
 		"vote": 15000,
 		"work": [2250, 4000],
 		"bankLimit": 250000,
-		"inventoryLimit": 3000000
+		"inventoryLimit": 3000000,
+		"farmPlots": 5
 	},
 	{
 		"falcoinsToLevelUp": 1050000,
 		"vote": 15500,
 		"work": [2500, 4500],
 		"bankLimit": 250000,
-		"inventoryLimit": 3000000
+		"inventoryLimit": 3000000,
+		"farmPlots": 5
 	},
 	{
 		"falcoinsToLevelUp": 1300000,
 		"vote": 16000,
 		"work": [2750, 5000],
 		"bankLimit": 300000,
-		"inventoryLimit": 3500000
+		"inventoryLimit": 3500000,
+		"farmPlots": 6
 	},
 	{
 		"falcoinsToLevelUp": 1600000,
 		"vote": 16500,
 		"work": [3000, 5500],
 		"bankLimit": 300000,
-		"inventoryLimit": 3500000
+		"inventoryLimit": 3500000,
+		"farmPlots": 6
 	},
 	{
 		"falcoinsToLevelUp": 2000000,
 		"vote": 17000,
 		"work": [3250, 6000],
 		"bankLimit": 300000,
-		"inventoryLimit": 4000000
+		"inventoryLimit": 4000000,
+		"farmPlots": 6
 	},
 	{
 		"falcoinsToLevelUp": 2500000,
 		"vote": 17500,
 		"work": [3500, 6500],
 		"bankLimit": 350000,
-		"inventoryLimit": 4000000
+		"inventoryLimit": 4000000,
+		"farmPlots": 7
 	},
 	{
 		"falcoinsToLevelUp": 3100000,
 		"vote": 18000,
 		"work": [3750, 6500],
 		"bankLimit": 350000,
-		"inventoryLimit": 4500000
+		"inventoryLimit": 4500000,
+		"farmPlots": 7
 	},
 	{
 		"falcoinsToLevelUp": 4000000,
 		"vote": 18500,
 		"work": [4000, 6500],
 		"bankLimit": 350000,
-		"inventoryLimit": 4500000
+		"inventoryLimit": 4500000,
+		"farmPlots": 7
 	},
 	{
 		"falcoinsToLevelUp": 5300000,
 		"vote": 19000,
 		"work": [4250, 6500],
 		"bankLimit": 400000,
-		"inventoryLimit": 5000000
+		"inventoryLimit": 5000000,
+		"farmPlots": 8
 	},
 	{
 		"falcoinsToLevelUp": 6700000,
 		"vote": 19500,
 		"work": [4500, 7000],
 		"bankLimit": 500000,
-		"inventoryLimit": 5000000
+		"inventoryLimit": 5000000,
+		"farmPlots": 8
 	},
 	{
 		"falcoinsToLevelUp": 7800000,
 		"vote": 20000,
 		"work": [5000, 8000],
 		"bankLimit": 600000,
-		"inventoryLimit": 5500000
+		"inventoryLimit": 5500000,
+		"farmPlots": 8
 	},
 	{
 		"falcoinsToLevelUp": 9100000,
 		"vote": 20500,
 		"work": [5500, 9000],
 		"bankLimit": 700000,
-		"inventoryLimit": 5500000
+		"inventoryLimit": 5500000,
+		"farmPlots": 9
 	},
 	{
 		"falcoinsToLevelUp": 10500000,
 		"vote": 21000,
 		"work": [6000, 10000],
 		"bankLimit": 700000,
-		"inventoryLimit": 6000000
+		"inventoryLimit": 6000000,
+		"farmPlots": 9
 	},
 	{
 		"falcoinsToLevelUp": 12100000,
 		"vote": 21500,
 		"work": [6500, 11000],
 		"bankLimit": 800000,
-		"inventoryLimit": 6000000
+		"inventoryLimit": 6000000,
+		"farmPlots": 9
 	},
 	{
 		"vote": 22000,
 		"work": [7000, 12000],
 		"bankLimit": 800000,
-		"inventoryLimit": 6500000
+		"inventoryLimit": 6500000,
+		"farmPlots": 10
 	}
 ]

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1937,9 +1937,9 @@
 		"es-ES": "🏞️ Granja de {USER}"
 	},
 	"WATERING_TIP": {
-		"pt-BR": "💦 **Regue as platações com `/fazenda regar` para diminir seu tempo de crescimento!**",
-		"en-US": "💦 **Water your crops with `/farm water` to decrease their growth time!**",
-		"es-ES": "💦 **¡Riega tus cultivos con `/granja regar` para disminuir su tiempo de crecimiento!**"
+		"pt-BR": "💦 **Regue as platações para diminir seu tempo de crescimento!**",
+		"en-US": "💦 **Water your crops to decrease their growth time!**",
+		"es-ES": "💦 **¡Riega tus cultivos con para disminuir su tiempo de crecimiento!**"
 	},
 	"PLOT": {
 		"pt-BR": "Terreno",

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -2020,5 +2020,55 @@
 		"pt-BR": "Não há colheitas para arrancar!",
 		"en-US": "There are no crops to uproot!",
 		"es-ES": "¡No hay cultivos para arrancar!"
+	},
+	"SELECT_CROP_PLACEHOLDER": {
+		"pt-BR": "Selecione uma cultura para plantar...",
+		"en-US": "Select a crop to plant...",
+		"es-ES": "Selecciona un cultivo para plantar..."
+	},
+	"SELECT_CROP": {
+		"pt-BR": "Selecione uma das culturas abaixo para plantar.\nVocê tem **{AMOUNT}** terrenos disponíveis.",
+		"en-US": "Select one of the crops below to plant.\nYou have **{AMOUNT}** plots available.",
+		"es-ES": "Selecciona uno de los cultivos de abajo para plantar.\nTienes **{AMOUNT}** terrenos disponibles."
+	},
+	"SELECT_PLOT_PLACEHOLDER": {
+		"pt-BR": "Selecione um terreno para arrancar...",
+		"en-US": "Select a plot to uproot...",
+		"es-ES": "Selecciona un terreno para arrancar..."
+	},
+	"SELECT_PLOT": {
+		"pt-BR": "Selecione um dos terrenos abaixo para arrancar:",
+		"en-US": "Select one of the plots below to uproot:",
+		"es-ES": "Selecciona uno de los terrenos de abajo para arrancar:"
+	},
+	"VIEW": {
+		"pt-BR": "Ver",
+		"en-US": "View",
+		"es-ES": "Ver"
+	},
+	"PLANT": {
+		"pt-BR": "Plantar",
+		"en-US": "Plant",
+		"es-ES": "Plantar"
+	},
+	"WATER": {
+		"pt-BR": "Regar",
+		"en-US": "Water",
+		"es-ES": "Regar"
+	},
+	"HARVEST": {
+		"pt-BR": "Colher",
+		"en-US": "Harvest",
+		"es-ES": "Cosechar"
+	},
+	"UPROOT": {
+		"pt-BR": "Arrancar",
+		"en-US": "Uproot",
+		"es-ES": "Arrancar"
+	},
+	"REMAINING": {
+		"pt-BR": "restante",
+		"en-US": "remaining",
+		"es-ES": "restante"
 	}
 }

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -2075,5 +2075,10 @@
 		"pt-BR": "Essa cultura não existe!",
 		"en-US": "That crop doesn't exist!",
 		"es-ES": "¡Ese cultivo no existe!"
+	},
+	"RANKUP_FARM": {
+		"pt-BR": "🏞️ *+{PLOTS} terreno disponível na sua fazenda*",
+		"en-US": "🏞️ *+{PLOTS} plot available in your farm*",
+		"es-ES": "🏞️ *+{PLOTS} terreno disponible en tu granja*"
 	}
 }

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -2115,5 +2115,10 @@
 		"pt-BR": "*Plantando e colhendo*",
 		"en-US": "*Planting and harvesting*",
 		"es-ES": "*Plantando y cosechando*"
+	},
+	"PLANTABLE": {
+		"pt-BR": "🌱 Plantável",
+		"en-US": "🌱 Plantable",
+		"es-ES": "🌱 Plantable"
 	}
 }

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1939,7 +1939,7 @@
 	"WATERING_TIP": {
 		"pt-BR": "💦 **Regue as platações para diminir seu tempo de crescimento!**",
 		"en-US": "💦 **Water your crops to decrease their growth time!**",
-		"es-ES": "💦 **¡Riega tus cultivos con para disminuir su tiempo de crecimiento!**"
+		"es-ES": "💦 **¡Riega tus cultivos para disminuir su tiempo de crecimiento!**"
 	},
 	"PLOT": {
 		"pt-BR": "Terreno",

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -2070,5 +2070,10 @@
 		"pt-BR": "restante",
 		"en-US": "remaining",
 		"es-ES": "restante"
+	},
+	"INVALID_CROP": {
+		"pt-BR": "Essa cultura não existe!",
+		"en-US": "That crop doesn't exist!",
+		"es-ES": "¡Ese cultivo no existe!"
 	}
 }

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1930,5 +1930,95 @@
 		"pt-BR": ":ledger: Ministro",
 		"en-US": ":ledger: Minister",
 		"es-ES": ":ledger: Ministro"
+	},
+	"FARM_TITLE": {
+		"pt-BR": "🏞️ Fazenda de {USER}",
+		"en-US": "🏞️ {USER}'s Farm",
+		"es-ES": "🏞️ Granja de {USER}"
+	},
+	"WATERING_TIP": {
+		"pt-BR": "💦 **Regue as platações com `/fazenda regar` para diminir seu tempo de crescimento!**",
+		"en-US": "💦 **Water your crops with `/farm water` to decrease their growth time!**",
+		"es-ES": "💦 **¡Riega tus cultivos con `/granja regar` para disminuir su tiempo de crecimiento!**"
+	},
+	"PLOT": {
+		"pt-BR": "Terreno",
+		"en-US": "Plot",
+		"es-ES": "Terreno"
+	},
+	"NO_PLOTS": {
+		"pt-BR": "Sem terrenos",
+		"en-US": "No plots",
+		"es-ES": "Sin terrenos"
+	},
+	"NO_PLOTS_HINT": {
+		"pt-BR": "Use `/fazenda plantar` para plantar uma colheita!",
+		"en-US": "Use `/farm plant` to plant a crop!",
+		"es-ES": "¡Usa `/granja plantar` para plantar un cultivo!"
+	},
+	"REMAINING_TIME": {
+		"pt-BR": "{CROP} em {TIME}",
+		"en-US": "{CROP} in {TIME}",
+		"es-ES": "{CROP} en {TIME}"
+	},
+	"READY_TO_HARVEST": {
+		"pt-BR": "Pronto para colher!",
+		"en-US": "Ready to harvest!",
+		"es-ES": "¡Listo para cosechar!"
+	},
+	"PLANTED": {
+		"pt-BR": "Plantado",
+		"en-US": "Planted",
+		"es-ES": "Plantado"
+	},
+	"PLOTS_AVAILABLE": {
+		"pt-BR": "**{CURRENT}** de **{MAX}** terrenos disponíveis.",
+		"en-US": "**{CURRENT}** of **{MAX}** plots available.",
+		"es-ES": "**{CURRENT}** de **{MAX}** terrenos disponibles."
+	},
+	"NO_PLOTS_AVAILABLE": {
+		"pt-BR": "Você não tem mais terrenos disponíveis!",
+		"en-US": "You don't have any plots available!",
+		"es-ES": "¡No tienes ningún terreno disponible!"
+	},
+	"PLOTS_WATERED": {
+		"pt-BR": "Você regou **{AMOUNT}** terrenos!",
+		"en-US": "You watered **{AMOUNT}** plots!",
+		"es-ES": "¡Regaste **{AMOUNT}** terrenos!"
+	},
+	"NO_PLOTS_WATERED": {
+		"pt-BR": "Você não regou nenhum terreno!",
+		"en-US": "You didn't water any plots!",
+		"es-ES": "¡No regaste ningún terreno!"
+	},
+	"CROPS_HARVESTED": {
+		"pt-BR": "🚜 Você colheu **{AMOUNT}** colheitas!",
+		"en-US": "🚜 You harvested **{AMOUNT}** crops!",
+		"es-ES": "🚜 ¡Cosechaste **{AMOUNT}** cultivos!"
+	},
+	"NO_CROPS_HARVESTED": {
+		"pt-BR": "Você não colheu nenhuma colheita!",
+		"en-US": "You didn't harvest any crops!",
+		"es-ES": "¡No cosechaste ningún cultivo!"
+	},
+	"NO_CROPS_TO_HARVEST": {
+		"pt-BR": "Não há colheitas para colher!",
+		"en-US": "There are no crops to harvest!",
+		"es-ES": "¡No hay cultivos para cosechar!"
+	},
+	"PLOTS_UPRROTED": {
+		"pt-BR": "Você arrancou {CROP} do terreno **{INDEX}!**",
+		"en-US": "You uprooted {CROP} from plot **{INDEX}!**",
+		"es-ES": "¡Arrancaste {CROP} del terreno **{INDEX}!**"
+	},
+	"INVALID_PLOT": {
+		"pt-BR": "Esse terreno não existe!",
+		"en-US": "That plot doesn't exist!",
+		"es-ES": "¡Ese terreno no existe!"
+	},
+	"NO_CROPS_TO_UPROOT": {
+		"pt-BR": "Não há colheitas para arrancar!",
+		"en-US": "There are no crops to uproot!",
+		"es-ES": "¡No hay cultivos para arrancar!"
 	}
 }

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -587,9 +587,9 @@
 		"es-ES": ":school_satchel: Sistema de items"
 	},
 	"HELP_ITEMS2": {
-		"pt-BR": "**:compass: Consiga items usando `/pescar`, `/caçar`, `/explorar`, `/minerar`\n:luggage: Veja todos os items que você ou outra pessoa tem com `/inventário ver`\n:moneybag: Items podem ser vendidos com `/inventário vender`\n:book: Veja todas as informações sobre um item como valores, raridade e usos com `/iteminfo`\n\n:hammer_pick: Items podem ser construídos com `/inventário construir`**\n-Calcule a quantidade de materiais necessários para construir com `/inventário calcular`\n-Alguns items podem ser equipados para garantir benefícios com `/inventário equipar`\n-Outros items podem ser usados e tem efeitos especiais com `/inventário usar`\n\n:busts_in_silhouette: Vocẽ pode trocar items com outros jogadores usando `/troca`\n**:convenience_store: Compre e venda itens no mercado, veja os itens disponíveis com `/mercado tudo` e as ofertas de um item específico com `/mercado ver`, anuncie com `/mercado anunciar compra` e `/mercado anunciar venda` e compre itens do mercado com `/mercado comprar`!**",
-		"en-US": "**:compass: Get items using `/fish`, `/hunt`, `/explore`, `/mine`\n:luggage: See all the items you or someone else has with `/inventory view`\n:moneybag: Items can be sold with `/inventory sell`\n:book: See all the information about an item such as values, rarity and uses with `/iteminfo`\n\n:hammer_pick: Items can be crafted with `/inventory craft`**\n-Calculate the amount of materials needed to craft with `/inventory calculate`\n-Some items can be equipped to grant benefits with `/inventory equip`\n-Other items can be used and have special effects with `/inventory use`\n\n:busts_in_silhouette: You can trade items with other players using `/trade`\n**:convenience_store: Buy and sell items in the market, see the available items with `/market all` and the offers of a specific item with `/market view`, announce with `/market announce buy` and `/market announce sell` and buy items from the market with `/market buy`!**",
-		"es-ES": "**:compass: Obtén items usando `/pescado`, `/cazar`, `/explorar`, `/minar`\n:luggage: Ver todos los items que tú o alguien más tiene con `/inventario ver`\n:moneybag: Los items se pueden vender con `/inventario vender`\n:book: Ver toda la información sobre un item como valores, rareza y usos con `/iteminfo`\n\n:hammer_pick: Los items se pueden construir con `/inventario construir`**\n-Calcule la cantidad de materiales necesarios para construir con `/inventario calcular`\n-Algunos items se pueden equipar para otorgar beneficios con `/inventario equipar`\n-Otros items se pueden usar y tienen efectos especiales con `/inventario usar`\n\n:busts_in_silhouette: Puedes intercambiar items con otros jugadores usando `/intercambio`\n**:convenience_store: ¡Compra y vende items en el mercado, ve los items disponibles con `/mercado todo` y las ofertas de un item específico con `/mercado ver`, anuncia con `/mercado anunciar compra` y `/mercado anunciar venta` y compra items del mercado con `/mercado comprar`!**"
+		"pt-BR": "**🧭 Consiga items usando `/pescar`, `/caçar`, `/explorar`, `/minerar`\n🧳 Veja todos os items que você ou outra pessoa tem com `/inventário ver`\n💰 Items podem ser vendidos com `/inventário vender`\n📖 Veja todas as informações sobre um item como valores, raridade e usos com `/iteminfo`\n\n⚒️ Items podem ser construídos com `/inventário construir`**\n-Calcule a quantidade de materiais necessários para construir com `/inventário calcular`\n-Alguns items podem ser equipados para garantir benefícios com `/inventário equipar`\n-Outros items podem ser usados e tem efeitos especiais com `/inventário usar`\n\n👥 Vocẽ pode trocar items com outros jogadores usando `/troca`\n**Para mais informações confira as páginas de 🏪 Mercado e 🏞️ Fazenda**",
+		"en-US": "**🧭 Get items using `/fish`, `/hunt`, `/explore`, `/mine`\n🧳 See all the items you or someone else has with `/inventory view`\n💰 Items can be sold with `/inventory sell`\n📖 See all the information about an item such as values, rarity and uses with `/iteminfo`\n\n⚒️ Items can be crafted with `/inventory craft`**\n-Calculate the amount of materials needed to craft with `/inventory calculate`\n-Some items can be equipped to grant benefits with `/inventory equip`\n-Other items can be used and have special effects with `/inventory use`\n\n👥 You can trade items with other players using `/trade`\n**For more information check the 🏪 Market and 🏞️ Farm pages**",
+		"es-ES": "**🧭 Obtén items usando `/pescar`, `/cazar`, `/explorar`, `/minerar`\n🧳 Ver todos los items que tú o alguien más tiene con `/inventario ver`\n💰 Los items se pueden vender con `/inventario vender`\n📖 Ver toda la información sobre un item como valores, rareza y usos con `/iteminfo`\n\n⚒️ Los items se pueden construir con `/inventario construir`**\n-Calcule la cantidad de materiales necesarios para construir con `/inventario calcular`\n-Algunos items se pueden equipar para otorgar beneficios con `/inventario equipar`\n-Otros items se pueden usar y tienen efectos especiales con `/inventario usar`\n\n👥 Puedes intercambiar items con otros jugadores usando `/intercambio`\n**Para más información, consulta las páginas de 🏪 Mercado y 🏞️ Granja**"
 	},
 	"HELP_CONFIG": {
 		"pt-BR": ":gear: Configurando o Falbot para o seu servidor",
@@ -2080,5 +2080,40 @@
 		"pt-BR": "🏞️ *+{PLOTS} terreno disponível na sua fazenda*",
 		"en-US": "🏞️ *+{PLOTS} plot available in your farm*",
 		"es-ES": "🏞️ *+{PLOTS} terreno disponible en tu granja*"
+	},
+	"HELP_MARKET": {
+		"pt-BR": "🏪 Vendendo e comprando no mercado",
+		"en-US": "🏪 Selling and buying on the market",
+		"es-ES": "🏪 Vender y comprar en el mercado"
+	},
+	"HELP_MARKET2": {
+		"pt-BR": "**O mercado é um lugar onde usuários podem comprar e vender itens entre si.**\n📦 Use `/mercado tudo` para ver todos os itens disponíveis no mercado.\n🔍 Veja todos os anúncios de um item específico com `/mercado ver`\n💰 Rapidamente compre um item do mercado com `/mercado comprar`\n\n**Tem itens de sobra ou quer algum em específico?**\n🛍️ Anuncie que quer comprar um item com `/mercado anunciar compra`\n🏷️ Anuncie que quer vender um item com `/mercado anunciar venda`\n📃 Veja todos os seus anúncios com `/mercado listagens`\n❌ Remova um anúncio com `/mercado retirar`",
+		"en-US": "**The market is a place where users can buy and sell items to each other.**\n📦 Use `/market all` to see all the items available on the market.\n🔍 See all the listings of a specific item with `/market view`\n💰 Quickly buy an item from the market with `/market buy`\n\n**Have extra items or want a specific one?**\n🛍️ List that you want to buy an item with `/market list buy`\n🏷️ List that you want to sell an item with `/market list sell`\n📃 See all your listings with `/market listings`\n❌ Remove a listing with `/market delist`",
+		"es-ES": "**El mercado es un lugar donde los usuarios pueden comprar y vender artículos entre sí.**\n📦 Usa `/mercado todo` para ver todos los artículos disponibles en el mercado.\n🔍 Ver todas las listas de un artículo específico con `/mercado ver`\n💰 Compra rápidamente un artículo del mercado con `/mercado comprar`\n\n**¿Tienes artículos extra o quieres uno específico?**\n🛍️ Anuncia que quieres comprar un artículo con `/mercado anunciar compra`\n🏷️ Anuncia que quieres vender un artículo con `/mercado anunciar venta`\n📃 Ver todas tus listas con `/mercado listados`\n❌ Elimina una lista con `/mercado retirar`"
+	},
+	"HELP_MARKET3": {
+		"pt-BR": "*Compre e venda itens*",
+		"en-US": "*Buy and sell items*",
+		"es-ES": "*Compra y vende artículos*"
+	},
+	"FARM": {
+		"pt-BR": "Fazenda",
+		"en-US": "Farm",
+		"es-ES": "Granja"
+	},
+	"HELP_FARM": {
+		"pt-BR": "🏞️ Cultivando sua fazenda",
+		"en-US": "🏞️ Farming your farm",
+		"es-ES": "🏞️ Cultivando tu granja"
+	},
+	"HELP_FARM2": {
+		"pt-BR": "**Na fazenda é possível plantar e colher certos itens**\n🪟 Veja sua fazenda com `/fazenda ver`\n🌱 Plante uma nova cultura com `/fazenda plantar`\n💦 Cada cultura pode ser regada a cada 2 horas com `/fazenda regar` isso diminui o tempo de crescimento\n🚜 Quando prontas as plantas podem ser colhidas com `/fazenda colher`\n🪓 Se arrependeu de algo que plantou? Arranque-a com `/fazenda arrancar`",
+		"en-US": "**On the farm you can plant and harvest certain items**\n🪟 View your farm with `/farm view`\n🌱 Plant a new crop with `/farm plant`\n💦 Each crop can be watered every 2 hours with `/farm water` this decreases the growth time\n🚜 When ready the crops can be harvested with `/farm harvest`\n🪓 Regret something you planted? Uproot it with `/farm uproot`",
+		"es-ES": "**En la granja puedes plantar y cosechar ciertos artículos**\n🪟 Ver tu granja con `/granja ver`\n🌱 Planta un nuevo cultivo con `/granja plantar`\n💦 Cada cultivo se puede regar cada 2 horas con `/granja regar` esto disminuye el tiempo de crecimiento\n🚜 Cuando estén listos los cultivos se pueden cosechar con `/granja cosechar`\n🪓 ¿Te arrepientes de algo que plantaste? Arráncalo con `/granja arrancar`"
+	},
+	"HELP_FARM3": {
+		"pt-BR": "*Plantando e colhendo*",
+		"en-US": "*Planting and harvesting*",
+		"es-ES": "*Plantando y cosechando*"
 	}
 }

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1937,7 +1937,7 @@
 		"es-ES": "🏞️ Granja de {USER}"
 	},
 	"WATERING_TIP": {
-		"pt-BR": "💦 **Regue as platações para diminir seu tempo de crescimento!**",
+		"pt-BR": "💦 **Regue as plantações para diminuir seu tempo de crescimento!**",
 		"en-US": "💦 **Water your crops to decrease their growth time!**",
 		"es-ES": "💦 **¡Riega tus cultivos para disminuir su tiempo de crecimiento!**"
 	},


### PR DESCRIPTION
> Closes #65

## Feature description

Adds a farming system to Falbot, users can plant seeds in their plots, as well as water, harvest, and uproot. When grown, the user can harvest them and earn a random amount of each type of crop planted.

### Subcommands already implemented:

- `/farm view`: show user's farm
- `/farm plant`: plant a crop
- `/farm harvest`: harvest all available crops
- `/farm water`: water all crops
- `/farm uproot`: uproot a specified plot

#### TODO:

- [x] Add crops values and rarities (new crops have value of 0)
- [x] Change max plots logic to adpt to the levels system
- [x] Add farming commands to `/help`
- [x] \(Optional) Other changes to be discussed in this PR

### Media, if applicable
![farm_view](https://github.com/falcao-g/Falbot/assets/56037523/febcdf9f-3d31-4c3b-8598-9b19c628dc48) 
|:--:| 
| `/farm view` |
![farm_plant](https://github.com/falcao-g/Falbot/assets/56037523/0b46a0af-2725-480a-811c-f1bf86cff33d)
| `/farm plant crop: 🍀 Clover` |
![farm_water](https://github.com/falcao-g/Falbot/assets/56037523/070f0fb0-6cbd-4eba-bcbc-9f63833f8c05)
| `/farm water` |
![farm_harvest](https://github.com/falcao-g/Falbot/assets/56037523/b23a0435-bd6b-45e4-b5f7-48a9f4996c36)
| `/farm harvest` |
![farm_uproot](https://github.com/falcao-g/Falbot/assets/56037523/5306dc44-b589-45f4-98f3-8461c1b7519b)
| `/farm uproot` |

and much more!
