### PR TITLE
feat: add the remaining falgames minigames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"discord.js": "^14.9.0",
 				"dotenv": "^16.0.1",
-				"falgames": "^1.1.1",
+				"falgames": "^1.2.0",
 				"mongoose": "^6.8.0",
 				"simply-blackjack": "^1.0.3"
 			},
@@ -2386,14 +2386,16 @@
 			}
 		},
 		"node_modules/falgames": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/falgames/-/falgames-1.1.1.tgz",
-			"integrity": "sha512-Dzdgz4RF+3ib7TeoY6tBqN6s3RQtQngZmN0ra5xzPNbSXPve5J9sXRQ3TsNCtVz5ezMaqu+2rzk+OT5kARMnRg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/falgames/-/falgames-1.2.0.tgz",
+			"integrity": "sha512-Nm4fGp9g+hN0VkTGHAf1tCDgZqcb4gOgRqegf5Gf1ma7jQwqXwu9jqxTRfxwYNuzqbc2fIbWOt7od3zfdyuGXA==",
 			"dependencies": {
 				"canvas": "^2.11.2",
 				"discord.js": "^14.14.1",
-				"html-entities": "^2.3.3",
-				"node-fetch": "^2.6.7"
+				"html-entities": "^2.3.3"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -6504,14 +6506,13 @@
 			}
 		},
 		"falgames": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/falgames/-/falgames-1.1.1.tgz",
-			"integrity": "sha512-Dzdgz4RF+3ib7TeoY6tBqN6s3RQtQngZmN0ra5xzPNbSXPve5J9sXRQ3TsNCtVz5ezMaqu+2rzk+OT5kARMnRg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/falgames/-/falgames-1.2.0.tgz",
+			"integrity": "sha512-Nm4fGp9g+hN0VkTGHAf1tCDgZqcb4gOgRqegf5Gf1ma7jQwqXwu9jqxTRfxwYNuzqbc2fIbWOt7od3zfdyuGXA==",
 			"requires": {
 				"canvas": "^2.11.2",
 				"discord.js": "^14.14.1",
-				"html-entities": "^2.3.3",
-				"node-fetch": "^2.6.7"
+				"html-entities": "^2.3.3"
 			}
 		},
 		"fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"discord.js": "^14.9.0",
 		"dotenv": "^16.0.1",
-		"falgames": "^1.1.1",
+		"falgames": "^1.2.0",
 		"mongoose": "^6.8.0",
 		"simply-blackjack": "^1.0.3"
 	},

--- a/src/bot.js
+++ b/src/bot.js
@@ -14,7 +14,7 @@ class Falbot {
 	emVal = (s) => s.split('').reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0);
 	client = new Client({
 		shards: 'auto',
-		intents: [GatewayIntentBits.Guilds],
+		intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent],
 	});
 	levels = require('./utils/json/levels.json');
 	items = require('./utils/json/items.json');

--- a/src/commands/fun/games.js
+++ b/src/commands/fun/games.js
@@ -1,5 +1,22 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { Connect4, FindEmoji, Flood, MatchPairs, Minesweeper, Snake, TicTacToe, TwoZeroFourEight } = require('falgames');
+const { randint } = require('../../utils/functions');
+const {
+	Connect4,
+	FindEmoji,
+	Flood,
+	MatchPairs,
+	Minesweeper,
+	Snake,
+	TicTacToe,
+	TwoZeroFourEight,
+	WouldYouRather,
+	Trivia,
+	FastType,
+	GuessThePokemon,
+	Hangman,
+	RockPaperScissors,
+	Wordle,
+} = require('falgames');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -134,6 +151,93 @@ module.exports = {
 				'pt-BR': 'Jogue o clássico jogo 2048',
 				'es-ES': 'Juega el clásico juego 2048',
 			})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('wouldyourather')
+				.setNameLocalizations({
+					'pt-BR': 'vocêprefere',
+					'es-ES': 'prefieres',
+				})
+				.setDescription('Choose what you would rather do')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Escolha o que você prefere fazer',
+					'es-ES': 'Elige qué preferirías hacer',
+				})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('trivia')
+				.setDescription('See how much useless knowledge you know')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Veja o quanto de conhecimento inútil você sabe',
+					'es-ES': 'Ve cuánto conocimiento inútil sabes',
+				})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('fasttype')
+				.setNameLocalizations({
+					'pt-BR': 'digiterápido',
+					'es-ES': 'escribirrápido',
+				})
+				.setDescription('Can you type fast?')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Você consegue digitar rápido?',
+					'es-ES': '¿Puedes escribir rápido?',
+				})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand.setName('pokemon').setDescription('What pokemon is this?').setDescriptionLocalizations({
+				'pt-BR': 'Que pokemon é esse?',
+				'es-ES': '¿Qué pokemon es este?',
+			})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('hangman')
+				.setNameLocalizations({
+					'pt-BR': 'forca',
+					'es-ES': 'ahorcado',
+				})
+				.setDescription('Find out the mystery word')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Descubra a palavra misteriosa',
+					'es-ES': 'Descubre la palabra misteriosa',
+				})
+		)
+		.addSubcommand((subcommand) =>
+			subcommand
+				.setName('rockpaperscissors')
+				.setNameLocalizations({
+					'pt-BR': 'jokenpô',
+					'es-ES': 'piedrapapeltijera',
+				})
+				.setDescription('Challenge someone to a game of rock paper scissors')
+				.setDescriptionLocalizations({
+					'pt-BR': 'Desafie alguém para um jogo de jokenpô',
+					'es-ES': 'Desafía a alguien a un juego de piedra papel tijera',
+				})
+				.addUserOption((option) =>
+					option
+						.setName('opponent')
+						.setNameLocalizations({
+							'pt-BR': 'oponente',
+							'es-ES': 'oponente',
+						})
+						.setDescription('opponent to play with')
+						.setDescriptionLocalizations({
+							'pt-BR': 'oponente para jogar',
+							'es-ES': 'oponente para jugar',
+						})
+						.setRequired(true)
+				)
+		)
+		.addSubcommand((subcommand) =>
+			subcommand.setName('wordle').setDescription('Play wordle from a random day').setDescriptionLocalizations({
+				'pt-BR': 'Jogue wordle de um dia aleatório',
+				'es-ES': 'Juega wordle de un día aleatorio',
+			})
 		),
 	execute: async ({ interaction, instance, subcommand, member }) => {
 		try {
@@ -150,7 +254,6 @@ module.exports = {
 					opponent: interaction.options.getUser('opponent'),
 					embed: {
 						title: ':brain: Connect4',
-						statusTitle: 'Status',
 						color: member.displayColor,
 					},
 					emojis: {
@@ -158,9 +261,7 @@ module.exports = {
 						player1: '🔴',
 						player2: '🟡',
 					},
-					mentionUser: true,
-					timeoutTime: 60000,
-					buttonStyle: 'PRIMARY',
+					timeoutTime: 1000 * 60,
 					turnMessage: instance.getMessage(interaction, 'FALGAMES_MOVE'),
 					winMessage: instance.getMessage(interaction, 'FALGAMES_WIN'),
 					tieMessage: instance.getMessage(interaction, 'FALGAMES_DRAW'),
@@ -177,9 +278,8 @@ module.exports = {
 						description: instance.getMessage(interaction, 'REMEMBER_THE_EMOJIS'),
 						findDescription: instance.getMessage(interaction, 'FIND_EMOJI_DESCRIPTION'),
 					},
-					timeoutTime: 60000,
-					hideEmojiTime: 5000,
-					buttonStyle: 'PRIMARY',
+					timeoutTime: 1000 * 60,
+					hideEmojiTime: 8000,
 					emojis: ['🍉', '🍇', '🍊', '🍋', '🥭', '🍎', '🍏', '🥝'],
 					winMessage: instance.getMessage(interaction, 'FIND_EMOJI_WIN'),
 					loseMessage: instance.getMessage(interaction, 'FIND_EMOJI_LOSE'),
@@ -195,8 +295,7 @@ module.exports = {
 						color: member.displayColor,
 					},
 					difficulty: 13,
-					timeoutTime: 60000,
-					buttonStyle: 'PRIMARY',
+					timeoutTime: 1000 * 60,
 					emojis: ['🟥', '🟦', '🟧', '🟪', '🟩'],
 					winMessage: instance.getMessage(interaction, 'FLOOD_WIN'),
 					loseMessage: instance.getMessage(interaction, 'FLOOD_LOSE'),
@@ -211,7 +310,7 @@ module.exports = {
 						color: member.displayColor,
 						description: instance.getMessage(interaction, 'MATCH_PAIRS_DESCRIPTION'),
 					},
-					timeoutTime: 60000,
+					timeoutTime: 1000 * 60,
 					emojis: ['🍉', '🍇', '🍊', '🥭', '🍎', '🍏', '🥝', '🥥', '🍓', '🫐', '🍍', '🥕', '🥔'],
 					winMessage: instance.getMessage(interaction, 'MATCH_PAIRS_WIN'),
 					loseMessage: instance.getMessage(interaction, 'MATCH_PAIRS_LOSE'),
@@ -228,7 +327,7 @@ module.exports = {
 					},
 					emojis: { flag: '🚩', mine: '💣' },
 					mines: 5,
-					timeoutTime: 60000,
+					timeoutTime: 1000 * 60,
 					winMessage: instance.getMessage(interaction, 'MINESWEEPER_WIN'),
 					loseMessage: instance.getMessage(interaction, 'MINESWEEPER_LOSE'),
 					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
@@ -253,7 +352,7 @@ module.exports = {
 					snake: { head: '🤑', body: '🟩', tail: '🟢', over: '💥' },
 					foods: ['💰', '🪙', '💵', '💎', '💸', '💳'],
 					stopButton: instance.getMessage(interaction, 'STOP'),
-					timeoutTime: 60000,
+					timeoutTime: 1000 * 60,
 					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
 				});
 			} else if (type === 'tictactoe') {
@@ -264,7 +363,6 @@ module.exports = {
 					embed: {
 						title: instance.getMessage(interaction, 'TICTACTOE'),
 						color: member.displayColor,
-						statusTitle: 'Status',
 						overTitle: instance.getMessage(interaction, 'GAME_OVER'),
 					},
 					emojis: {
@@ -272,10 +370,7 @@ module.exports = {
 						oButton: '🔵',
 						blankButton: '➖',
 					},
-					mentionUser: true,
-					timeoutTime: 60000,
-					xButtonStyle: 'DANGER',
-					oButtonStyle: 'PRIMARY',
+					timeoutTime: 1000 * 60,
 					turnMessage: instance.getMessage(interaction, 'FALGAMES_MOVE'),
 					winMessage: instance.getMessage(interaction, 'FALGAMES_WIN'),
 					tieMessage: instance.getMessage(interaction, 'FALGAMES_DRAW'),
@@ -288,7 +383,7 @@ module.exports = {
 					isSlashGame: true,
 					embed: {
 						title: '🔢 2048',
-						color: '#551476',
+						color: member.displayColor,
 					},
 					emojis: {
 						up: '⬆️',
@@ -296,9 +391,131 @@ module.exports = {
 						left: '⬅️',
 						right: '➡️',
 					},
-					timeoutTime: 60000,
+					timeoutTime: 1000 * 60,
 					stopButton: instance.getMessage(interaction, 'STOP'),
-					buttonStyle: 'PRIMARY',
+					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
+					scoreText: instance.getMessage(interaction, 'SCORE'),
+					totalScoreText: instance.getMessage(interaction, 'SCORE'),
+				});
+			} else if (type === 'wouldyourather') {
+				var Game = new WouldYouRather({
+					message: interaction,
+					isSlashGame: true,
+					embed: {
+						title: instance.getMessage(interaction, 'WOULD_YOU_RATHER'),
+						color: member.displayColor,
+					},
+					buttons: {
+						option1: '\u200b',
+						option2: '\u200b',
+					},
+					errMessage: instance.getMessage(interaction, 'EXCEPTION'),
+					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
+				});
+			} else if (type === 'trivia') {
+				var Game = new Trivia({
+					message: interaction,
+					isSlashGame: true,
+					embed: {
+						title: '❔ Trivia',
+						description: instance.getMessage(interaction, 'TRIVIA_DESCRIPTION'),
+						color: member.displayColor,
+					},
+					timeoutTime: 1000 * 60,
+					mode: ['multiple', 'single'][randint(0, 1)],
+					difficulty: ['easy', 'medium', 'hard'][randint(0, 2)],
+					winMessage: instance.getMessage(interaction, 'TRIVIA_WIN'),
+					loseMessage: instance.getMessage(interaction, 'TRIVIA_LOSE'),
+					errMessage: instance.getMessage(interaction, 'EXCEPTION'),
+					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
+				});
+			} else if (type === 'fasttype') {
+				const sentences = instance.getMessage(interaction, 'SENTENCES');
+				const sentence = sentences[randint(0, sentences.length - 1)];
+				var Game = new FastType({
+					message: interaction,
+					isSlashGame: true,
+					embed: {
+						title: instance.getMessage(interaction, 'FAST_TYPE'),
+						description: instance.getMessage(interaction, 'TIME_TO_TYPE'),
+						color: member.displayColor,
+					},
+					timeoutTime: 1000 * 600,
+					sentence: sentence,
+					winMessage: instance.getMessage(interaction, 'FAST_TYPE_WIN'),
+					loseMessage: instance.getMessage(interaction, 'FAST_TYPE_LOSE'),
+				});
+			} else if (type === 'pokemon') {
+				var Game = new GuessThePokemon({
+					message: interaction,
+					isSlashGame: true,
+					embed: {
+						title: instance.getMessage(interaction, 'POKEMON'),
+						color: member.displayColor,
+					},
+					timeoutTime: 1000 * 60,
+					winMessage: instance.getMessage(interaction, 'POKEMON_WIN'),
+					loseMessage: instance.getMessage(interaction, 'POKEMON_LOSE'),
+					errMessage: instance.getMessage(interaction, 'EXCEPTION'),
+					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
+					typesText: instance.getMessage(interaction, 'TYPES'),
+					abilitiesText: instance.getMessage(interaction, 'ABILITIES'),
+				});
+			} else if (type === 'hangman') {
+				const words = instance.getMessage(interaction, 'HANGMAN_WORDS');
+				const word = words[randint(0, words.length - 1)];
+				var Game = new Hangman({
+					message: interaction,
+					isSlashGame: true,
+					embed: {
+						title: instance.getMessage(interaction, 'HANGMAN'),
+						color: member.displayColor,
+					},
+					hangman: { hat: '🎩', head: '😟', shirt: '👕', pants: '🩳', boots: '👞👞' },
+					customWord: word,
+					timeoutTime: 1000 * 60,
+					winMessage: instance.getMessage(interaction, 'WORDS_WIN'),
+					loseMessage: instance.getMessage(interaction, 'WORDS_LOSE'),
+					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
+				});
+			} else if (type === 'rockpaperscissors') {
+				var Game = new RockPaperScissors({
+					message: interaction,
+					isSlashGame: true,
+					opponent: interaction.options.getUser('opponent'),
+					embed: {
+						title: '🪨📄✂️',
+						description: instance.getMessage(interaction, 'BUTTON_BELOW'),
+						color: member.displayColor,
+					},
+					buttons: {
+						rock: instance.getMessage(interaction, 'ROCK'),
+						paper: instance.getMessage(interaction, 'PAPER'),
+						scissors: instance.getMessage(interaction, 'SCISSORS'),
+					},
+					emojis: {
+						rock: '🌑',
+						paper: '📰',
+						scissors: '✂️',
+					},
+					timeoutTime: 1000 * 60,
+					pickMessage: instance.getMessage(interaction, 'RPS_CHOICE'),
+					winMessage: instance.getMessage(interaction, 'RPS_WIN'),
+					tieMessage: instance.getMessage(interaction, 'FALGAMES_DRAW'),
+					timeoutMessage: instance.getMessage(interaction, 'FALGAMES_TIMEOUT'),
+					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY_2'),
+				});
+			} else if (type === 'wordle') {
+				var Game = new Wordle({
+					message: interaction,
+					isSlashGame: true,
+					embed: {
+						title: 'Wordle',
+						color: member.displayColor,
+					},
+					timeoutTime: 1000 * 600,
+					winMessage: instance.getMessage(interaction, 'WORDS_WIN'),
+					loseMessage: instance.getMessage(interaction, 'WORDS_LOSE'),
 					playerOnlyMessage: instance.getMessage(interaction, 'PLAYER_ONLY'),
 				});
 			}

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -2110,5 +2110,225 @@
 		"pt-BR": "🌱 Plantável",
 		"en-US": "🌱 Plantable",
 		"es-ES": "🌱 Plantable"
+	},
+	"WOULD_YOU_RATHER": {
+		"pt-BR": ":thinking: Você prefere...",
+		"en-US": ":thinking: Would you rather...",
+		"es-ES": ":thinking: ¿Preferirías..."
+	},
+	"FAST_TYPE": {
+		"pt-BR": "⌨️ Digite o mais rápido que puder!",
+		"en-US": "⌨️ Type as fast as you can!",
+		"es-ES": "⌨️ ¡Escribe lo más rápido que puedas!"
+	},
+	"TIME_TO_TYPE": {
+		"pt-BR": "Você tem {time} segundos para digitar a frase abaixo.",
+		"en-US": "You have {time} seconds to type the sentence below.",
+		"es-ES": "Tienes {time} segundos para escribir la oración a continuación."
+	},
+	"SENTENCES": {
+		"pt-BR": [
+			"Num buraco no chão vivia um hobbit. Não uma toca desagradável, suja e úmida, cheia de restos de minhocas e com cheiro de lodo, nem uma toca seca, nua e arenosa, sem nada em que se sentar ou o que comer: era uma toca-hobbit, e isso significa conforto.",
+			"O barulho das explosões ao longe e do contrafogo retumbante da artilharia em terra invadiu o centro de comando. A sala estremeceu. Grãos de poeira caíam das tubulações e de cabos no teto, e as luminárias piscavam. Tarkin monitorava os holovídeos das transmissões terrestres.",
+			"O retrato, como já disse, era o de uma jovem. Mostrava apenas a cabeça e os ombros, pintados naquilo que tecnicamente é denominado vignette; muito no estilo das cabeças favoritas de Sully. Os braços, o colo e até mesmo as pontas do cabelo radiante fundiam-se de maneira imperceptível na sombra vaga porém densa que formava o pano de fundo do conjunto",
+			"Acho que o Rowley merece os parabéns por ter conseguido encontrar uma garota que goste dele. Mas isso não significa que eu esteja FELIZ com isso. Nos bons tempos, quando éramos só eu e ele, nós podiámos fazer o que desse vontade.",
+			"Trate o inimigo irritável com uma abordagem provocativa. Torne ainda mais orgulhoso o inimigo que te despreza. Procure cansar o inimigo descansado e enfraquecer com discórdia o inimigo que goza de harmonia. Aproveite a oportunidade e ataque o inimigo quando ele não estiver preparado, dando um golpe repentino e inesperado.",
+			"Eis o que diz a Enciclopédia Galáctica a respeito do álcool: é um líquido volátil e incolor formado pela fermentação dos açúcares. Acrescenta ainda que o álcool tem o efeito de inebriar certas formas de via baseadas em carbono. O Guia do Mochileiro das Galáxias também menciona o álcool. Diz que o melhor drinque que existe é a Dinamite Pangalática."
+		],
+		"en-US": [
+			"In a hole in the ground there lived a hobbit. Not a nasty, dirty, wet hole, filled with the ends of worms and an oozy smell, nor yet a dry, bare, sandy hole with nothing in it to sit down on or to eat: it was a hobbit-hole, and that means comfort.",
+			"The noise of distant explosions and the booming counterfire of artillery on the ground shook the command center. The room trembled. Dust fell from the pipes and cables in the ceiling, and the lights flickered. Tarkin monitored the holovids of the ground transmissions.",
+			"The portrait, as I said before, was of a young woman. It showed only the head and shoulders, painted in what is technically called a vignette; very much in the style of Sully's favorite heads. The arms, the bosom, and even the ends of the radiant hair melted imperceptibly into the vague but dense shadow which formed the back-ground of the whole.",
+			"Treat the irritable enemy with a provocative approach. Make the enemy who despises you even more proud. Try to tire the rested enemy and weaken the enemy who enjoys harmony with discord. Take the opportunity and attack the enemy when he is not prepared, giving a sudden and unexpected blow.",
+			"Here is what the Encyclopedia Galactica has to say about alcohol: it is a volatile liquid and colorless formed by the fermentation of sugars. It further adds that alcohol has the effect of intoxicating certain forms of travel based on carbon. The Hitchhiker's Guide to the Galaxy also mentions alcohol. It says that the best drink there is is the Pan Galactic Dynamite."
+		],
+		"es-ES": [
+			"En un agujero en el suelo vivía un hobbit. No un agujero desagradable, sucio y húmedo, lleno de extremos de gusanos y un olor viscoso, ni un agujero seco, desnudo y arenoso sin nada en lo que sentarse o comer: era un agujero de hobbit, y eso significa comodidad.",
+			"El ruido de las explosiones a distancia y el contrafuego retumbante de la artillería en tierra sacudieron el centro de mando. La habitación tembló. El polvo caía de las tuberías y cables del techo, y las luces parpadeaban. Tarkin monitoreó los holovideos de las transmisiones terrestres.",
+			"El retrato, como dije antes, era de una joven. Mostraba solo la cabeza y los hombros, pintados en lo que técnicamente se llama viñeta; muy al estilo de las cabezas favoritas de Sully. Los brazos, el pecho e incluso las puntas del cabello radiante se fundieron imperceptiblemente en la sombra vaga pero densa que formaba el fondo de todo el conjunto.",
+			"Trata al enemigo irritable con un enfoque provocativo. Haz que el enemigo que te desprecia esté aún más orgulloso. Intente cansar al enemigo descansado y debilitar al enemigo que disfruta de la armonía con la discordia. Aprovecha la oportunidad y ataca al enemigo cuando no esté preparado, dando un golpe repentino e inesperado.",
+			"Esto es lo que dice la Enciclopedia Galáctica sobre el alcohol: es un líquido volátil e incoloro formado por la fermentación de azúcares. Además agrega que el alcohol tiene el efecto de intoxicar ciertas formas de viaje basadas en carbono. La Guía del autoestopista galáctico también menciona el alcohol. Dice que la mejor bebida que existe es la Dinamita Pan Galáctica."
+		]
+	},
+	"FAST_TYPE_WIN": {
+		"pt-BR": "Você ganhou! Você digitou a frase em {time} segundos, digitando {wpm} palavras por minuto!",
+		"en-US": "You won! You typed the sentence in {time} seconds, typing {wpm} words per minute!",
+		"es-ES": "¡Ganaste! Escribiste la oración en {time} segundos, escribiendo {wpm} palabras por minuto!"
+	},
+	"FAST_TYPE_LOSE": {
+		"pt-BR": "Você perdeu! Você não digitou a frase rápido o suficiente!",
+		"en-US": "You lost! You didn't type the sentence fast enough!",
+		"es-ES": "¡Perdiste! ¡No escribiste la oración lo suficientemente rápido!"
+	},
+	"TRIVIA_WIN": {
+		"pt-BR": "Você ganhou! A resposta certa é {answer}.",
+		"en-US": "You won! The correct answer is {answer}.",
+		"es-ES": "¡Ganaste! La respuesta correcta es {answer}."
+	},
+	"TRIVIA_LOSE": {
+		"pt-BR": "Você perdeu! A resposta certa é {answer}.",
+		"en-US": "You lost! The correct answer is {answer}.",
+		"es-ES": "¡Perdiste! La respuesta correcta es {answer}."
+	},
+	"TRIVIA_DESCRIPTION": {
+		"pt-BR": "Você tem 60 segundos para responder a pergunta.",
+		"en-US": "You have 60 seconds to answer the question.",
+		"es-ES": "Tienes 60 segundos para responder la pregunta."
+	},
+	"POKEMON": {
+		"pt-BR": "Quem é esse Pokémon?",
+		"en-US": "Who's The Pokemon?",
+		"es-ES": "¿Quién es ese Pokémon?"
+	},
+	"POKEMON_WIN": {
+		"pt-BR": "Você adivinhou corretamente! Era um {pokemon}.",
+		"en-US": "You guessed correctly! It was a {pokemon}.",
+		"es-ES": "¡Adivinaste correctamente! Era un {pokemon}."
+	},
+	"POKEMON_LOSE": {
+		"pt-BR": "Mais sorte na próxima! Era um {pokemon}.",
+		"en-US": "Better luck next time! It was a {pokemon}.",
+		"es-ES": "Mejor suerte la próxima vez! Era un {pokemon}."
+	},
+	"TYPES": {
+		"pt-BR": "Tipos",
+		"en-US": "Types",
+		"es-ES": "Tipos"
+	},
+	"ABILITIES": {
+		"pt-BR": "Habilidades",
+		"en-US": "Abilities",
+		"es-ES": "Habilidades"
+	},
+	"HANGMAN": {
+		"pt-BR": "🪢 Forca",
+		"en-US": "🪢 Hangman",
+		"es-ES": "🪢 Ahorcado"
+	},
+	"WORDS_WIN": {
+		"pt-BR": "Você ganhou! A palavra era **{word}**.",
+		"en-US": "You won! The word was **{word}**.",
+		"es-ES": "¡Ganaste! La palabra era **{word}**."
+	},
+	"WORDS_LOSE": {
+		"pt-BR": "Você perdeu! A palavra era **{word}**.",
+		"en-US": "You lost! The word was **{word}**.",
+		"es-ES": "¡Perdiste! La palabra era **{word}**."
+	},
+	"HANGMAN_WORDS": {
+		"pt-BR": [
+			"cachoeira",
+			"ilha",
+			"grama",
+			"lago",
+			"oceano",
+			"azul",
+			"verde",
+			"amarelo",
+			"roxo",
+			"laranja",
+			"futebol",
+			"basquete",
+			"boxe",
+			"skate",
+			"abacaxi",
+			"banana",
+			"morango",
+			"uva",
+			"kiwi",
+			"melancia",
+			"gelo",
+			"casaco",
+			"blusa",
+			"elefante",
+			"tigre",
+			"cachorro",
+			"gato"
+		],
+		"en-US": [
+			"waterfall",
+			"island",
+			"grass",
+			"lake",
+			"ocean",
+			"blue",
+			"green",
+			"yellow",
+			"purple",
+			"orange",
+			"football",
+			"basketball",
+			"boxing",
+			"skate",
+			"pineapple",
+			"banana",
+			"strawberry",
+			"grape",
+			"kiwi",
+			"watermelon",
+			"ice",
+			"jacket",
+			"sweater",
+			"elephant",
+			"tiger",
+			"dog",
+			"cat"
+		],
+		"es-ES": [
+			"cascada",
+			"isla",
+			"hierba",
+			"lago",
+			"azul",
+			"verde",
+			"amarillo",
+			"naranja",
+			"baloncesto",
+			"boxeo",
+			"patineta",
+			"fresa",
+			"uva",
+			"kiwi",
+			"hielo",
+			"chaqueta",
+			"elefante",
+			"tigre",
+			"perro",
+			"gato",
+			"naranja",
+			"manzana",
+			"pera",
+			"ciruela"
+		]
+	},
+	"ROCK": {
+		"pt-BR": "Pedra",
+		"en-US": "Rock",
+		"es-ES": "Piedra"
+	},
+	"PAPER": {
+		"pt-BR": "Papel",
+		"en-US": "Paper",
+		"es-ES": "Papel"
+	},
+	"SCISSORS": {
+		"pt-BR": "Tesoura",
+		"en-US": "Scissors",
+		"es-ES": "Tijeras"
+	},
+	"BUTTON_BELOW": {
+		"pt-BR": "Pressione um botão abaixo para fazer uma escolha.",
+		"en-US": "Press a button below to make a choice.",
+		"es-ES": "Presiona un botón a continuación para hacer una elección."
+	},
+	"RPS_CHOICE": {
+		"pt-BR": "Você escolheu {emoji}.",
+		"en-US": "You choose {emoji}.",
+		"es-ES": "Elegiste {emoji}."
+	},
+	"RPS_WIN": {
+		"pt-BR": "**{player}** ganhou o jogo! Parabéns!",
+		"en-US": "'**{player}** won the Game! Congratulations!'",
+		"es-ES": "**{player}** ganó el juego! ¡Felicidades!"
 	}
 }


### PR DESCRIPTION
## What does this PR do?
Update falgames to v1.2.0 and add the remaining minigames, since now falbot can read message contents

## Summary of changes
- Add would you rather
- Add trivia
- Add fast type
- Add guess the pokemon
- Add hangman
- Add rock paper scissors
- Add wordle

## Media
<img width="735" alt="image" src="https://github.com/falcao-g/Falbot/assets/60127788/0b403684-2c63-4d27-9735-513af25450d9">
<img width="523" alt="image" src="https://github.com/falcao-g/Falbot/assets/60127788/cd6be5f4-5c98-49b2-9409-2b225d524d20">
<img width="488" alt="image" src="https://github.com/falcao-g/Falbot/assets/60127788/039a03f9-5804-45da-9503-e4f38e52c685">
<img width="756" alt="image" src="https://github.com/falcao-g/Falbot/assets/60127788/d71caf9b-4615-45f5-bcb6-1a5915204740">
