### PR TITLE
feat: turbo market and inventory sellall commands

### DIFF
--- a/src/database/market.js
+++ b/src/database/market.js
@@ -90,21 +90,21 @@ module.exports = {
 		await marketSchema.findByIdAndUpdate(result.id, result);
 	},
 	async getBuyOrdersFromUser(id) {
-		const result = await marketSchema.find();
+		const result = await marketSchema.find({ 'buyOrders.owner': id });
 		var orders = [];
 		result.forEach((item) => {
 			item.buyOrders.forEach((order) => {
-				if (order.owner === id) orders.push({ ...order, item: item._id });
+				if (order.owner === id) orders.push({ amount: order.amount, price: order.price, item: item._id, owner: id });
 			});
 		});
 		return orders;
 	},
 	async getSellOrdersFromUser(id) {
-		const result = await marketSchema.find();
+		const result = await marketSchema.find({ 'sellOrders.owner': id });
 		var orders = [];
 		result.forEach((item) => {
 			item.sellOrders.forEach((order) => {
-				if (order.owner === id) orders.push({ ...order, item: item._id });
+				if (order.owner === id) orders.push({ amount: order.amount, price: order.price, item: item._id, owner: id });
 			});
 		});
 		return orders;
@@ -120,5 +120,15 @@ module.exports = {
 		var index = findOrderByItemAndOwner(result.sellOrders, item, owner);
 		result.sellOrders.splice(index, 1);
 		await marketSchema.findByIdAndUpdate(result.id, result);
+	},
+	async getHistory(id) {
+		const result = await marketSchema.findOne({ _id: id });
+		return result.history;
+	},
+	async addHistory(id, message) {
+		var result = await marketSchema.findOne({ _id: id });
+		result.history.unshift(message);
+		result.history = result.history.slice(0, 100);
+		result.save();
 	},
 };

--- a/src/schemas/market-schema.js
+++ b/src/schemas/market-schema.js
@@ -1,17 +1,42 @@
 const mongoose = require('mongoose');
 
+const order = mongoose.Schema({
+	_id: false,
+	owner: {
+		type: String,
+		required: true,
+	},
+	amount: {
+		type: Number,
+		required: true,
+	},
+	price: {
+		type: Number,
+		required: true,
+	},
+});
+
 const marketSchema = mongoose.Schema(
 	{
 		_id: {
 			type: String,
 			required: true,
 		},
-		buyOrders: {
+		buyOrders: [
+			{
+				type: order,
+				default: [],
+			},
+		],
+		sellOrders: [
+			{
+				type: order,
+				default: [],
+			},
+		],
+		history: {
 			type: Array,
-			default: [],
-		},
-		sellOrders: {
-			type: Array,
+			of: String,
 			default: [],
 		},
 	},

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -126,11 +126,16 @@ function randint(low, high) {
  */
 function paginate() {
 	const __embeds = [];
+	const __components = [];
 	let cur = 0;
 	let traverser;
 	return {
 		add(...embeds) {
 			__embeds.push(...embeds);
+			return this;
+		},
+		addComponents(...components) {
+			__components.push(...components);
 			return this;
 		},
 		setTraverser(tr) {
@@ -149,9 +154,20 @@ function paginate() {
 			}
 		},
 		components() {
+			if (__components.length == 0) {
+				return {
+					embeds: [__embeds.at(cur)],
+					components: [new ActionRowBuilder().addComponents(...traverser)],
+					fetchReply: true,
+				};
+			}
+
 			return {
 				embeds: [__embeds.at(cur)],
-				components: [new ActionRowBuilder().addComponents(...traverser)],
+				components: [
+					new ActionRowBuilder().addComponents(__components.at(cur)),
+					new ActionRowBuilder().addComponents(...traverser),
+				],
 				fetchReply: true,
 			};
 		},

--- a/src/utils/json/messages.json
+++ b/src/utils/json/messages.json
@@ -1281,6 +1281,16 @@
 		"en-US": ":money_with_wings: You are about to sell **EVERYTHING** from your inventory\n:eye: Mythical items are not included.",
 		"es-ES": ":money_with_wings: Estás a punto de vender **TODO** de tu inventario\n:eye: Los artículos míticos no están incluidos."
 	},
+	"SELLALL_LOOTONLY": {
+		"pt-BR": "\n:compass: Você escolheu vender apenas os itens de loot.",
+		"en-US": "\n:compass: You chose to sell only loot items.",
+		"es-ES": "\n:compass: Elegiste vender solo artículos de botín."
+	},
+	"SELLALL_NOLEGENDARY": {
+		"pt-BR": "\n:milky_way: Itens lendários não serão vendidos.",
+		"en-US": "\n:milky_way: Legendary items will not be sold.",
+		"es-ES": "\n:milky_way: Los artículos legendarios no se venderán."
+	},
 	"SELLALL_CONFIRMED_TITLE": {
 		"pt-BR": ":moneybag: Inventário vendido!",
 		"en-US": ":moneybag: Inventory sold!",
@@ -1592,9 +1602,9 @@
 		"es-ES": ":shopping_cart: Mercado ({PAGE}/{TOTAL})"
 	},
 	"NO_LISTINGS": {
-		"pt-BR": "Não listado",
-		"en-US": "No listings",
-		"es-ES": "Sin listados"
+		"pt-BR": "Indisponível",
+		"en-US": "Unavailable",
+		"es-ES": "No disponible"
 	},
 	"AVAILABLES": {
 		"pt-BR": "Disponíveis",
@@ -1602,14 +1612,14 @@
 		"es-ES": "Disponibles"
 	},
 	"BUYERS": {
-		"pt-BR": "Compradores",
-		"en-US": "Buyers",
-		"es-ES": "Compradores"
+		"pt-BR": "Venda por",
+		"en-US": "Sell for",
+		"es-ES": "Vender por"
 	},
 	"SELLERS": {
-		"pt-BR": "Vendedores",
-		"en-US": "Sellers",
-		"es-ES": "Vendedores"
+		"pt-BR": "Compre por",
+		"en-US": "Buy for",
+		"es-ES": "Compra por"
 	},
 	"MARKET_BOUGHT": {
 		"pt-BR": "Você comprou {AMOUNT} {ITEM} por {PRICE} falcoins!",
@@ -2330,5 +2340,30 @@
 		"pt-BR": "**{player}** ganhou o jogo! Parabéns!",
 		"en-US": "'**{player}** won the Game! Congratulations!'",
 		"es-ES": "**{player}** ganó el juego! ¡Felicidades!"
+	},
+	"MARKET_MENU": {
+		"pt-BR": "Veja um mercado...",
+		"en-US": "View a market...",
+		"es-ES": "Ver un mercado..."
+	},
+	"MARKET_HISTORY": {
+		"pt-BR": ":shopping_bags: Histórico de transações de {ITEM} {PAGE}/{TOTAL}",
+		"en-US": ":shopping_bags: Transaction history of {ITEM} {PAGE}/{TOTAL}",
+		"es-ES": ":shopping_bags: Historial de transacciones de {ITEM} {PAGE}/{TOTAL}"
+	},
+	"NO_HISTORY": {
+		"pt-BR": ":hourglass: Esse item não foi vendido no mercado ainda.",
+		"en-US": ":hourglass: This item hasn't been sold on the market yet.",
+		"es-ES": ":hourglass: Este artículo aún no se ha vendido en el mercado."
+	},
+	"HISTORY_BOUGHT": {
+		"pt-BR": "{ITEM} x {AMOUNT} foram comprados por {PRICE} falcoins.",
+		"en-US": "{ITEM} x {AMOUNT} were bought for {PRICE} falcoins.",
+		"es-ES": "{ITEM} x {AMOUNT} fueron comprados por {PRICE} falcoins."
+	},
+	"HISTORY_SOLD": {
+		"pt-BR": "{ITEM} x {AMOUNT} foram vendidos por {PRICE} falcoins.",
+		"en-US": "{ITEM} x {AMOUNT} were sold for {PRICE} falcoins.",
+		"es-ES": "{ITEM} x {AMOUNT} fueron vendidos por {PRICE} falcoins."
 	}
 }


### PR DESCRIPTION
- **feat: improve paginate function**
- **feat: boost up market and inventory sellall commands**

closes #124 

## What does this PR do?
Turbos up market and inventory sellall commands to work better

## Summary of changes
- Adds market history
- Adds qol texts to /inventory sellall
- Makes /inventory sellall consider market orders
- Adds a select menu for each page in /market all
- Improves paginate function to paginate components as well
- Improves market schema