### PR TITLE
fix: market history

### DIFF
--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -481,15 +481,12 @@ module.exports = {
 					sellerFile.falcoins += sellOrder.price * amount;
 					await database.market.subtractQuantityFromSellOrder(itemKey, sellOrder, amount);
 					sellerFile.stats.listingsSold += amount;
+					await database.market.addHistory(itemKey, {
+						price: format(sellOrder.price),
+						amount: format(amount),
+						item: instance.getItemName(itemKey, interaction),
+					});
 					amount = 0;
-					await database.market.addHistory(
-						itemKey,
-						instance.getMessage(interaction, 'HISTORY_BOUGHT', {
-							PRICE: format(sellOrder.price),
-							AMOUNT: format(amount),
-							ITEM: instance.getItemName(itemKey, interaction),
-						})
-					);
 				}
 				await sellerFile.save();
 			}

--- a/src/commands/economy/market.js
+++ b/src/commands/economy/market.js
@@ -465,14 +465,11 @@ module.exports = {
 					userFile.inventory.set(itemKey, (userFile.inventory.get(itemKey) || 0) + sellOrder.amount);
 					sellerFile.falcoins += sellOrder.price * sellOrder.amount;
 					await database.market.subtractQuantityFromSellOrder(itemKey, sellOrder, sellOrder.amount);
-					await database.market.addHistory(
-						itemKey,
-						instance.getMessage(interaction, 'HISTORY_BOUGHT', {
-							PRICE: format(sellOrder.price * sellOrder.amount),
-							AMOUNT: format(sellOrder.amount),
-							ITEM: instance.getItemName(itemKey, interaction),
-						})
-					);
+					await database.market.addHistory(itemKey, {
+						price: format(sellOrder.price * sellOrder.amount),
+						amount: format(sellOrder.amount),
+						item: instance.getItemName(itemKey, interaction),
+					});
 					sellerFile.stats.listingsSold += sellOrder.amount;
 				} else {
 					userFile.falcoins -= sellOrder.price * amount;
@@ -887,13 +884,21 @@ module.exports = {
 					const embed = instance.createEmbed(member.displayColor);
 
 					const historyOnPage = history.slice(i * 15, (i + 1) * 15);
+					var formattedHistory = historyOnPage.map((entry) =>
+						instance.getMessage(interaction, 'HISTORY_BOUGHT', {
+							PRICE: entry.price,
+							AMOUNT: entry.amount,
+							ITEM: entry.item,
+						})
+					);
+
 					embed.addFields({
 						name: instance.getMessage(interaction, 'MARKET_HISTORY', {
 							ITEM: instance.getItemName(itemKey, interaction),
 							PAGE: i + 1,
 							TOTAL: numberOfPages,
 						}),
-						value: historyOnPage.join('\n'),
+						value: formattedHistory.join('\n'),
 					});
 
 					return embed;

--- a/src/database/market.js
+++ b/src/database/market.js
@@ -125,10 +125,10 @@ module.exports = {
 		const result = await marketSchema.findOne({ _id: id });
 		return result.history;
 	},
-	async addHistory(id, message) {
+	async addHistory(id, { price, amount, item }) {
 		var result = await marketSchema.findOne({ _id: id });
-		result.history.unshift(message);
-		result.history = result.history.slice(0, 100);
+		result.history.unshift({ price, amount, item });
+		result.history = result.history.slice(0, 1000);
 		result.save();
 	},
 };

--- a/src/schemas/market.js
+++ b/src/schemas/market.js
@@ -36,7 +36,6 @@ const marketSchema = mongoose.Schema(
 		],
 		history: {
 			type: Array,
-			of: String,
 			default: [],
 		},
 	},


### PR DESCRIPTION
## What does this PR do?
Fixes some issues in market history, like sometimes saying that 0 items were sold or messages havind different language

## Summary of changes
- Fixes a bug where sometimes it would say that 0 items were bought
- Changes market history schema to just be an array insteado of an array of string
- Fixes a bug where messages in market history could be different languages, because we saved strings, now we save objects
